### PR TITLE
✨ feat: 팀 페이지 전체 구성 정리

### DIFF
--- a/src/app/(workspace)/[teamId]/page.tsx
+++ b/src/app/(workspace)/[teamId]/page.tsx
@@ -11,11 +11,21 @@ import { isSameDay, parseISO } from "date-fns";
 import MemberBox from "@/components/feature/Dashboard/MemberGroup/MemberBox";
 import { useModalStore } from "@/stores/modalStore";
 import ProfileModal from "@/components/common/Modal/ProfileModal";
+import Label from "@/components/feature/Dashboard/Label/Label";
+import TodoModal from "@/components/common/Modal/TodoModal";
+import InviteModal from "@/components/common/Modal/InviteModal";
 
 export default function DashboardPage() {
   const router = useRouter();
   const { teamId } = useParams();
   const { openModal } = useModalStore();
+
+  const isCurrentAdmin =
+    mockTeamData.members.find((m) => m.userEmail === currentUser.userEmail)
+      ?.role === "ADMIN";
+
+  const taskListCount = mockTeamData.taskLists.length;
+  const memberCount = mockTeamData.members.length;
 
   const pointColors = [
     "bg-point-purple",
@@ -60,76 +70,100 @@ export default function DashboardPage() {
     profileImageUrl: string;
   } | null>(null);
 
+  const [todoTitle, setTodoTitle] = useState("");
+
   return (
     <div className="w-full flex-col flex gap-12">
       <TeamBar teamName={mockTeamData.name} />
       <div className="flex flex-col gap-4">
-        {/* TODO: API 연결 */}
-        {mockTeamData.taskLists.map((list, index) => {
-          const doneCount = list.tasks.filter(
-            (task) => task.doneAt !== null,
-          ).length;
-          const totalCount = list.tasks.length;
-          const colorClass = pointColors[index % pointColors.length];
-
-          return (
-            <div key={list.id} onClick={() => handleListClick(list.id)}>
-              <ListBar
-                listName={list.name}
-                done={doneCount}
-                total={totalCount}
-                colorClass={colorClass}
-              />
+        <Label
+          title="할 일 목록"
+          count={`(${taskListCount}개)`}
+          modalButton="+ 목록 추가하기"
+          onClickModalButton={() => openModal("todo")}
+        />
+        {taskListCount === 0 ? (
+          <div className="w-full h-32 flex items-center justify-center">
+            <div className="text-text-default text-md">
+              아직 할 일 목록이 없습니다.
             </div>
-          );
-        })}
+          </div>
+        ) : (
+          // TODO: API 연결
+          mockTeamData.taskLists.map((list, index) => {
+            const doneCount = list.tasks.filter(
+              (task) => task.doneAt !== null,
+            ).length;
+            const totalCount = list.tasks.length;
+            const colorClass = pointColors[index % pointColors.length];
+
+            return (
+              <div key={list.id} onClick={() => handleListClick(list.id)}>
+                <ListBar
+                  listName={list.name}
+                  done={doneCount}
+                  total={totalCount}
+                  colorClass={colorClass}
+                />
+              </div>
+            );
+          })
+        )}
       </div>
-      <div className="w-full flex bg-bg-secondary h-[13.5625rem] p-6 pl-6 sm:pl-8 rounded-xl items-center justify-between gap-6 sm:gap-14">
-        <ReportChart done={todayDoneCount} total={todayTotalCount} />
-        <div className="flex flex-col w-full gap-4 items-end">
-          <ReportBox
-            content="오늘의 할 일"
-            count={todayTotalCount}
-            image="/icons/icon-avatar.svg"
-          />
-          <ReportBox
-            content="한 일"
-            count={todayDoneCount}
-            image="/icons/icon-done.svg"
-          />
+
+      <div className="flex flex-col gap-4">
+        <Label title="리포트" />
+        <div className="w-full flex bg-bg-secondary h-[13.5625rem] p-6 pl-6 sm:pl-8 rounded-xl items-center justify-between gap-6 sm:gap-14">
+          <ReportChart done={todayDoneCount} total={todayTotalCount} />
+          <div className="flex flex-col w-full gap-4 items-end">
+            <ReportBox
+              content="오늘의 할 일"
+              count={todayTotalCount}
+              image="/icons/icon-avatar.svg"
+            />
+            <ReportBox
+              content="한 일"
+              count={todayDoneCount}
+              image="/icons/icon-done.svg"
+            />
+          </div>
         </div>
       </div>
-      <div className="w-full grid grid-cols-2 sm:grid-cols-3 gap-4 sm:gap-6">
-        {/* TODO: API 연결 */}
-        {mockTeamData.members.map((member) => {
-          const isSelf = member.userEmail === currentUser.userEmail;
-          const isCurrentAdmin =
-            mockTeamData.members.find(
-              (m) => m.userEmail === currentUser.userEmail,
-            )?.role === "ADMIN";
+      <div className="flex flex-col gap-4">
+        <Label
+          title="멤버"
+          count={`(${memberCount}명)`}
+          modalButton="+ 새로운 멤버 초대하기"
+          showModalButton={isCurrentAdmin}
+          onClickModalButton={() => openModal("invite")}
+        />
+        <div className="w-full grid grid-cols-2 sm:grid-cols-3 gap-4 sm:gap-6">
+          {/* TODO: API 연결 */}
+          {mockTeamData.members.map((member) => {
+            const isSelf = member.userEmail === currentUser.userEmail;
+            const isAbleButton = isCurrentAdmin ? !isSelf : isSelf;
 
-          const isAbleButton = isCurrentAdmin ? !isSelf : isSelf;
-
-          return (
-            <MemberBox
-              key={member.userId + member.userEmail}
-              profile={member.userImage}
-              name={member.userName}
-              email={member.userEmail}
-              isAdmin={member.role === "ADMIN"}
-              isSelf={isSelf}
-              isAbleButton={isAbleButton}
-              onClickProfile={() => {
-                setSelectedProfile({
-                  name: member.userName,
-                  email: member.userEmail,
-                  profileImageUrl: member.userImage,
-                });
-                openModal("profile");
-              }}
-            />
-          );
-        })}
+            return (
+              <MemberBox
+                key={member.userId + member.userEmail}
+                profile={member.userImage}
+                name={member.userName}
+                email={member.userEmail}
+                isAdmin={member.role === "ADMIN"}
+                isSelf={isSelf}
+                isAbleButton={isAbleButton}
+                onClickProfile={() => {
+                  setSelectedProfile({
+                    name: member.userName,
+                    email: member.userEmail,
+                    profileImageUrl: member.userImage,
+                  });
+                  openModal("profile");
+                }}
+              />
+            );
+          })}
+        </div>
       </div>
       {selectedProfile && (
         <ProfileModal
@@ -138,10 +172,25 @@ export default function DashboardPage() {
           profileImageUrl={selectedProfile.profileImageUrl}
           onCopy={() => {
             navigator.clipboard.writeText(selectedProfile.email);
-            alert("이메일이 복사되었습니다!"); // TODO: 모달 연결
+            alert("이메일이 복사되었습니다!"); // TODO: 토스트 연결
           }}
         />
       )}
+      <TodoModal
+        value={todoTitle}
+        onChange={(e) => setTodoTitle(e.target.value)}
+        onSubmit={(e) => {
+          e.preventDefault();
+          // TODO: API 연결
+          setTodoTitle("");
+        }}
+      />
+      <InviteModal
+        onCopy={() => {
+          navigator.clipboard.writeText("https://coworkers/invite"); // TODO: 실제 링크 연결
+          alert("초대 링크가 복사되었습니다!"); // TODO: 토스트 연결
+        }}
+      />
     </div>
   );
 }

--- a/src/components/feature/Dashboard/Label/Label.tsx
+++ b/src/components/feature/Dashboard/Label/Label.tsx
@@ -1,0 +1,32 @@
+type Props = {
+  title: string;
+  count?: string;
+  modalButton?: string;
+  showModalButton?: boolean;
+  onClickModalButton?: () => void;
+};
+
+export default function Label({
+  title,
+  count,
+  modalButton,
+  showModalButton = true,
+  onClickModalButton,
+}: Props) {
+  return (
+    <div className="w-full flex justify-between">
+      <div className="flex gap-2">
+        <div className="font-medium text-lg text-text-primary">{title}</div>
+        <div className="font-normal text-lg text-text-default">{count}</div>
+      </div>
+      {modalButton && showModalButton && (
+        <div
+          className="text-brand-primary font-normal text-md cursor-pointer"
+          onClick={onClickModalButton}
+        >
+          {modalButton}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/feature/Dashboard/ReportGroup/ReportChart.tsx
+++ b/src/components/feature/Dashboard/ReportGroup/ReportChart.tsx
@@ -33,7 +33,7 @@ function ReportCircle({ done, total }: Props) {
   const radius = (size - stroke) / 2;
   const center = size / 2;
   const circumference = 2 * Math.PI * radius;
-  const progress = (done / total) * circumference;
+  const progress = total === 0 ? 0 : (done / total) * circumference;
 
   return (
     <svg width={size} height={size} className="rotate-[-90deg] w-full h-full">
@@ -67,7 +67,7 @@ function ReportCircle({ done, total }: Props) {
 }
 
 export default function ReportChart({ done, total }: Props) {
-  const percentage = total === 0 ? 100 : (done / total) * 100;
+  const percentage = total === 0 ? 0 : (done / total) * 100;
 
   return (
     <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-12">


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
Closes #109 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 라벨 추가
- 할 일 목록 없을 때 띄울 화면 구성
- 전체 페이지 구성 정리
  - 관리자: 목록 추가, 멤버 초대, 멤버 강퇴 가능
  - 멤버: 목록 추가, 본인 삭제 가능
- 피그마상 할 일이 0개 일 때 리포트 부분 차트가 0%로 뜨는 것 같아 반영하였습니다.

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
- 멤버 화면
![localhost_3000_1234](https://github.com/user-attachments/assets/62b107f9-9e00-44d8-a1a1-e5b11b012314)
- 관리자 화면
![localhost_3000_1234 (1)](https://github.com/user-attachments/assets/63312fb2-a07e-4029-9dc5-ca038e6b9026)


## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. `/1234` 페이지 확인
2. `mock.ts`에서 currentUser의 userEmail을 관리자 계정(test@email.com)으로 하면 관리자 화면으로, 다른 계정(test1@email.com)으로 하면 멤버 화면으로 뜹니다.
3. 모달 정상 작동 -> 모달에서 넘어가는 API 구현은 아직입니다.

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
