### PR TITLE
✨ feat: 계정 설정 페이지 API 연동

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,12 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  images: {
+    domains: [
+      "img1.kakaocdn.net",
+      "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/api/user/user.query.ts
+++ b/src/api/user/user.query.ts
@@ -10,6 +10,7 @@ import { authService } from "../auth/auth.service";
 import { useRouter } from "next/navigation";
 import { UpdateMyInfoRequest } from "./user.schema";
 import { Message } from "../auth/auth.schema";
+import { useToastStore } from "@/stores/toastStore";
 
 const userQuery = {
   all: ["user"],
@@ -64,6 +65,7 @@ export const useUpdateMyInfoMutation = () => {
 export const useDeleteMyInfoMutation = () => {
   const clearAuth = useAuthStore((state) => state.clearAuth);
   const router = useRouter();
+  const { showToast } = useToastStore();
 
   return useMutation({
     mutationFn: async () => {
@@ -73,6 +75,7 @@ export const useDeleteMyInfoMutation = () => {
     },
     onSuccess: () => {
       router.push("/");
+      showToast("탈퇴되었습니다.");
     },
   });
 };

--- a/src/app/(auth)/user-setting/page.tsx
+++ b/src/app/(auth)/user-setting/page.tsx
@@ -1,17 +1,26 @@
+"use client";
+
 import Input from "@/components/common/Input/Input";
 import PasswordChanger from "@/components/feature/Auth/SettingForm/PasswordChanger";
 import Secession from "@/components/feature/Auth/SettingForm/Secession";
 import SettingForm from "@/components/feature/Auth/SettingForm/SettingForm";
+import { useAuthStore } from "@/stores/authStore";
 
 export default function UserSettingPage() {
+  const { user } = useAuthStore();
+
+  if (!user) return <div>로그인 정보가 없습니다.</div>;
+
+  console.log(user);
+
   return (
     <div className="w-full">
       <h3 className="mb-6 text-2lg font-bold sm:text-xl">계정 설정</h3>
-      <SettingForm />
+      <SettingForm userName={user?.nickname} />
       <Input
         id="email"
         label="이메일"
-        defaultValue="유저 이메일 연결"
+        defaultValue={user?.email}
         hasTopMargin
         disabled
       />

--- a/src/app/(auth)/user-setting/page.tsx
+++ b/src/app/(auth)/user-setting/page.tsx
@@ -11,8 +11,6 @@ export default function UserSettingPage() {
 
   if (!user) return <div>로그인 정보가 없습니다.</div>;
 
-  console.log(user);
-
   return (
     <div className="w-full">
       <h3 className="mb-6 text-2lg font-bold sm:text-xl">계정 설정</h3>
@@ -25,7 +23,7 @@ export default function UserSettingPage() {
         disabled
       />
       <PasswordChanger />
-      <Secession />
+      {!user.email.toLowerCase().includes("kakao") && <Secession />}
     </div>
   );
 }

--- a/src/components/feature/Auth/SettingForm/PasswordChanger.tsx
+++ b/src/components/feature/Auth/SettingForm/PasswordChanger.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useUpdatePassword } from "@/api/user/user.query";
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input/Input";
 import PasswordChangeModal from "@/components/common/Modal/PasswordChangeModal";
@@ -15,6 +16,7 @@ interface FormValues {
 
 function PasswordChanger() {
   const { openModal, closeModal } = useModalStore();
+  const updatePasswordMutation = useUpdatePassword();
   const { showToast } = useToastStore();
 
   const {
@@ -33,7 +35,21 @@ function PasswordChanger() {
       return;
     }
 
-    console.log("비밀번호 변경 API");
+    updatePasswordMutation.mutate(
+      {
+        passwordConfirmation: data.confirmPassword,
+        password: data.newPassword,
+      },
+      {
+        onSuccess: () => {
+          showToast("비밀번호가 변경되었습니다.", "success");
+        },
+        onError: () => {
+          showToast("비밀번호 변경을 실패했습니다.", "error");
+        },
+      },
+    );
+
     closeModal();
     reset();
   };

--- a/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
+++ b/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
@@ -11,9 +11,8 @@ import React, { useCallback, useRef, useState } from "react";
 function ProfileImageUploader() {
   const inputRef = useRef<HTMLInputElement>(null);
   const { user, setAuth } = useAuthStore();
-  const [imgSrc, setImgSrc] = useState(
-    user?.image || "/icons/icon-profile-default.svg",
-  );
+  const initialImgSrc = user?.image || "/icons/icon-profile-default.svg";
+  const [imgSrc, setImgSrc] = useState(initialImgSrc);
   const imageUpload = useUploadImage();
   const updateMyInfoMutation = useUpdateMyInfoMutation();
   const { showToast } = useToastStore();
@@ -43,9 +42,6 @@ function ProfileImageUploader() {
       imageUpload.mutate(file, {
         onSuccess: (uploadedUrl) => {
           setImgSrc(uploadedUrl);
-          if (user) {
-            setAuth({ ...user, image: uploadedUrl });
-          }
           updateMyInfoMutation.mutate(
             { image: uploadedUrl },
             {
@@ -54,8 +50,9 @@ function ProfileImageUploader() {
               },
               onError: (error) => {
                 console.log(error);
-                setImgSrc(user?.image || "/icons/icon-profile-default.svg");
                 showToast("정보 수정을 실패했습니다.", "error");
+
+                setImgSrc(initialImgSrc);
                 if (user) {
                   setAuth({ ...user, image: user.image });
                 }
@@ -65,8 +62,11 @@ function ProfileImageUploader() {
         },
         onError: (error) => {
           console.log(error);
-          setImgSrc(user?.image || "/icons/icon-profile-default.svg");
+          setImgSrc(initialImgSrc);
           showToast("이미지 변경을 실패했습니다.", "error");
+          if (user) {
+            setAuth({ ...user, image: user.image });
+          }
         },
       });
     },
@@ -76,8 +76,9 @@ function ProfileImageUploader() {
       imgSrc,
       updateImagePreview,
       showToast,
-      setAuth,
       updateMyInfoMutation,
+      setAuth,
+      initialImgSrc,
     ],
   );
 

--- a/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
+++ b/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
@@ -1,27 +1,91 @@
 "use client";
 
+import { useUploadImage } from "@/api/image/image-api";
+import { useUpdateMyInfoMutation } from "@/api/user/user.query";
+import { useAuthStore } from "@/stores/authStore";
+import { useToastStore } from "@/stores/toastStore";
+import { processImageFile } from "@/utils/imageUploadHelpers";
 import Image from "next/image";
-import React, { useRef } from "react";
+import React, { useCallback, useRef, useState } from "react";
 
 function ProfileImageUploader() {
   const inputRef = useRef<HTMLInputElement>(null);
+  const { user, setAuth } = useAuthStore();
+  const [imgSrc, setImgSrc] = useState(
+    user?.image || "/icons/icon-profile-default.svg",
+  );
+  const imageUpload = useUploadImage();
+  const updateMyInfoMutation = useUpdateMyInfoMutation();
+  const { showToast } = useToastStore();
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     inputRef.current?.click();
-  };
+  }, []);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  const updateImagePreview = useCallback((newPreview: string | null) => {
+    if (newPreview) {
+      setImgSrc(newPreview);
+    }
+  }, []);
 
-    // 이미지 업로드 뮤테이션 연결
-  };
+  const handleChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      processImageFile(file, imgSrc, (newPreviewUrl, processedFile) => {
+        void processedFile;
+        if (newPreviewUrl) {
+          updateImagePreview(newPreviewUrl);
+        }
+      });
+
+      imageUpload.mutate(file, {
+        onSuccess: (uploadedUrl) => {
+          setImgSrc(uploadedUrl);
+          if (user) {
+            setAuth({ ...user, image: uploadedUrl });
+          }
+          updateMyInfoMutation.mutate(
+            { image: uploadedUrl },
+            {
+              onSuccess: () => {
+                showToast("프로필 이미지를 변경하였습니다.", "success");
+              },
+              onError: (error) => {
+                console.log(error);
+                setImgSrc(user?.image || "/icons/icon-profile-default.svg");
+                showToast("정보 수정을 실패했습니다.", "error");
+                if (user) {
+                  setAuth({ ...user, image: user.image });
+                }
+              },
+            },
+          );
+        },
+        onError: (error) => {
+          console.log(error);
+          setImgSrc(user?.image || "/icons/icon-profile-default.svg");
+          showToast("이미지 변경을 실패했습니다.", "error");
+        },
+      });
+    },
+    [
+      user,
+      imageUpload,
+      imgSrc,
+      updateImagePreview,
+      showToast,
+      setAuth,
+      updateMyInfoMutation,
+    ],
+  );
 
   return (
     <div className="relative w-16 h-16 cursor-pointer" onClick={handleClick}>
       <Image
         className="rounded-full object-cover w-full h-full"
-        src="/icons/icon-profile-default.svg"
+        src={imgSrc}
         alt="프로필"
         width={64}
         height={64}

--- a/src/components/feature/Auth/SettingForm/Secession.tsx
+++ b/src/components/feature/Auth/SettingForm/Secession.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDeleteMyInfoMutation } from "@/api/user/user.query";
 import DeleteAccountModal from "@/components/common/Modal/DeleteAccountModal";
 import { useModalStore } from "@/stores/modalStore";
 import Image from "next/image";
@@ -7,14 +8,14 @@ import React from "react";
 
 function Secession() {
   const { openModal } = useModalStore();
+  const deleteMyInfoMutation = useDeleteMyInfoMutation();
 
   const openDeleteAccountModal = () => {
     openModal("delete-account");
   };
 
   const handleDeleteAccount = () => {
-    // 회원 탈퇴 API 연결
-    console.log("탈퇴");
+    deleteMyInfoMutation.mutate();
   };
 
   return (

--- a/src/components/feature/Auth/SettingForm/SettingForm.tsx
+++ b/src/components/feature/Auth/SettingForm/SettingForm.tsx
@@ -11,7 +11,7 @@ interface SettingForm {
   name: string;
 }
 
-function SettingForm() {
+function SettingForm({ userName }: { userName: string }) {
   const {
     register,
     handleSubmit,
@@ -29,7 +29,7 @@ function SettingForm() {
         <Input
           id="name"
           label="이름"
-          defaultValue="유저 이름 연결"
+          defaultValue={userName}
           {...register("name", {
             required: "이름을 입력해주세요.",
             maxLength: {

--- a/src/components/feature/Auth/SettingForm/SettingForm.tsx
+++ b/src/components/feature/Auth/SettingForm/SettingForm.tsx
@@ -6,6 +6,8 @@ import Input from "@/components/common/Input/Input";
 import Button from "@/components/common/Button";
 import { useForm } from "react-hook-form";
 import ErrorMsg from "@/components/common/Input/ErrorMsg";
+import { useUpdateMyInfoMutation } from "@/api/user/user.query";
+import { useToastStore } from "@/stores/toastStore";
 
 interface SettingForm {
   name: string;
@@ -17,9 +19,21 @@ function SettingForm({ userName }: { userName: string }) {
     handleSubmit,
     formState: { errors },
   } = useForm<SettingForm>({ mode: "onBlur" });
+  const updateMyInfoMutation = useUpdateMyInfoMutation();
+  const { showToast } = useToastStore();
 
   const onSubmit = (data: SettingForm) => {
-    console.log("프로필 업데이트 API:", data);
+    updateMyInfoMutation.mutate(
+      { nickname: data.name },
+      {
+        onSuccess: () => {
+          showToast("이름을 변경했습니다.", "success");
+        },
+        onError: () => {
+          showToast("이름 변경을 실패했습니다.", "error");
+        },
+      },
+    );
   };
 
   return (


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
closes #105

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
프로필 이미지 및 이름 변경, 비밀번호 재설정, 회원 탈퇴 기능 추가

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 로그인 후 /user-setting 페이지에서 각 기능 테스트 가능합니다.

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
카카오 로그인 후 회원 탈퇴 시도 시 API 오류 없이 처리되지만, 실제 카카오와의 연동은 끊기지 않는 것으로 확인됩니다.
이에 따라 우선 카카오 로그인 시 탈퇴 버튼이 노출되지 않도록 구현했습니다.
추후 해당 기능 수정 또는 카카오 로그인 여부 검사 로직을 강화해볼 예정입니다.