### PR TITLE
✨ feat: 팀 수정 페이지 UI 구현

### DIFF
--- a/src/app/(team)/edit/page.tsx
+++ b/src/app/(team)/edit/page.tsx
@@ -1,3 +1,27 @@
+"use client";
+import TeamFormLayout from "@/components/team/TeamFormLayout";
+import ProfileUploader from "@/components/team/ProfileUploader";
+import { TEAM_FORM_LABELS } from "@/constants/team";
+
+const handleEdit = () => {};
+
 export default function TeamEditPage() {
-  return <div>팀 수정 페이지 (준비 중)</div>;
+  return (
+    <>
+      <TeamFormLayout
+        title="팀 수정하기"
+        buttonLabel="수정하기"
+        onSubmit={handleEdit}
+        tip="팀 이름은 회사명이나 모임 이름 등으로 설정하면 좋아요."
+      >
+        <span className="inline-block font-medium text-lg pb-[0.75rem]">
+          {TEAM_FORM_LABELS.PROFILE}
+        </span>
+        <ProfileUploader />
+        <span className="inline-block font-medium text-lg pt-[1.5rem] pb-[0.75rem]">
+          {TEAM_FORM_LABELS.NAME}
+        </span>
+      </TeamFormLayout>
+    </>
+  );
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
Closes #113 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
- 팀 수정 페이지 UI 구현
- 반응형 스타일링 적용 (모바일/태블릿/노트북&데스크톱)

## 📸 스크린샷
https://github.com/user-attachments/assets/db7d8818-cf18-44c5-a8c3-9acb1eba78d4

## 🛠️ 테스트 방법
1. /edit 경로 진입
2. 피그마와 UI 동일한지 확인
3. 반응형 동작 확인

## 💡 추가 정보
- 현재 UI 구현 단계에서는 프로필 이미지 및 팀 이름이 비어있는 상태입니다! 추후 기능 구현 시 수정 페이지에 진입하면 팀 이름이 작성되어 있고, 프로필 이미지가 업로드되어있는 상태로 변경될 예정입니다.!