### PR TITLE
✨ feat: 팀페이지 팀데이터 API 연결

### DIFF
--- a/src/api/group/group.query.ts
+++ b/src/api/group/group.query.ts
@@ -1,10 +1,82 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AcceptInvitationRequest,
+  AddGroupMemberRequest,
+  CreateGroupRequest,
+  GetGroupResponse,
+  UpdateGroupRequest,
+} from "./group.schema";
 import { groupService } from "./group.service";
-import { GetGroupResponse } from "./group.schema";
 
+// 그룹 정보 조회
 export const useGroupQuery = (groupId: string) => {
   return useQuery<GetGroupResponse>({
     queryKey: ["group", groupId],
     queryFn: () => groupService.getGroup(groupId),
+  });
+};
+
+// 그룹 생성
+export const useCreateGroup = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateGroupRequest) => groupService.createGroup(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["groups"] });
+    },
+  });
+};
+
+// 그룹 수정
+export const useUpdateGroup = (id: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpdateGroupRequest) =>
+      groupService.updateGroup(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["group", id] });
+    },
+  });
+};
+
+// 그룹 삭제
+export const useDeleteGroup = (id: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => groupService.deleteGroup(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["group"] });
+    },
+  });
+};
+
+// 초대 수락
+export const useAcceptInvitation = () => {
+  return useMutation({
+    mutationFn: (body: AcceptInvitationRequest) =>
+      groupService.acceptInvitation(body),
+  });
+};
+
+// 멤버 추가
+export const useAddGroupMember = (id: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: AddGroupMemberRequest) =>
+      groupService.addGroupMember(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["group", id] });
+    },
+  });
+};
+
+// 멤버 삭제
+export const useDeleteGroupMember = (id: string, userId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => groupService.deleteMember(id, userId.toString()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["group", id] });
+    },
   });
 };

--- a/src/api/group/group.schema.ts
+++ b/src/api/group/group.schema.ts
@@ -1,4 +1,5 @@
 import { TaskListType } from "../task-list/task-list.schema";
+import { TaskDetailType } from "../task/task.schema";
 
 export type GroupType = {
   teamId?: string;
@@ -20,7 +21,7 @@ export type MemberType = {
 
 export type GetGroupResponse = GroupType & {
   members: MemberType[];
-  taskLists: (TaskListType & { tasks: string[] })[];
+  taskLists: (TaskListType & { tasks: TaskDetailType[] })[];
 };
 
 export type UpdateGroupRequest = {

--- a/src/components/feature/Dashboard/MemberGroup/MemberBox.tsx
+++ b/src/components/feature/Dashboard/MemberGroup/MemberBox.tsx
@@ -41,14 +41,20 @@ export default function MemberBox({
       <div className="w-full hidden sm:flex gap-3 min-w-0">
         <Image src={profile} alt="프로필 이미지" width={32} height={32} />
         <div className="flex flex-col w-full gap-0.5 min-w-0">
-          <div className="flex items-center font-medium text-md text-text-primary line-clamp-1">
-            {name}
-            <div className="font-light text-xs text-text-disabled ml-1">
-              {isAdmin && "(관리자)"}
+          <div className="flex items-center font-medium text-md text-text-primary gap-1 w-full">
+            <div className="truncate whitespace-nowrap overflow-hidden text-ellipsis max-w-full">
+              {name}
             </div>
-            <div className="font-light text-xs text-text-disabled">
-              {!isAdmin && isSelf && "(나)"}
-            </div>
+            {isAdmin && (
+              <div className="flex-shrink-0 font-light text-xs text-text-disabled">
+                (관리자)
+              </div>
+            )}
+            {!isAdmin && isSelf && (
+              <div className="flex-shrink-0 font-light text-xs text-text-disabled">
+                (나)
+              </div>
+            )}
           </div>
           <div className="font-normal text-sm text-text-secondary break-words overflow-hidden text-ellipsis line-clamp-2">
             {email}
@@ -58,14 +64,20 @@ export default function MemberBox({
       <div className="flex flex-col w-full h-full sm:hidden items-center gap-1.5 min-w-0">
         <div className="flex w-full gap-2 items-center">
           <Image src={profile} alt="프로필 이미지" width={24} height={24} />
-          <div className="flex items-center font-medium text-md text-text-primary line-clamp-1">
-            {name}
-            <div className="font-light text-xs text-text-disabled ml-1">
-              {isAdmin && "(관리자)"}
+          <div className="flex-1 flex items-center font-medium text-md text-text-primary gap-1 min-w-0">
+            <div className="truncate whitespace-nowrap overflow-hidden text-ellipsis max-w-full">
+              {name}
             </div>
-            <div className="font-light text-xs text-text-disabled">
-              {!isAdmin && isSelf && "(나)"}
-            </div>
+            {isAdmin && (
+              <div className="flex-shrink-0 font-light text-xs text-text-disabled">
+                (관리자)
+              </div>
+            )}
+            {!isAdmin && isSelf && (
+              <div className="flex-shrink-0 font-light text-xs text-text-disabled">
+                (나)
+              </div>
+            )}
           </div>
         </div>
         <div className="w-full font-normal text-sm text-text-secondary break-words overflow-hidden text-ellipsis line-clamp-1">

--- a/src/components/feature/Dashboard/TeamBar/TeamBar.tsx
+++ b/src/components/feature/Dashboard/TeamBar/TeamBar.tsx
@@ -3,13 +3,17 @@ import TeamBarDropdown from "./TeamBarDropdown";
 
 interface TeamBarProps {
   teamName: string;
+  showDropdown: boolean;
 }
 
-export default function TeamBar({ teamName }: TeamBarProps) {
+export default function TeamBar({
+  teamName,
+  showDropdown = true,
+}: TeamBarProps) {
   return (
     <div className="w-full h-16 bg-bg-bar border border-bg-bar rounded-xl relative px-6 flex items-center justify-between">
       <div className="font-bold text-xl text-text-inverse z-10">{teamName}</div>
-      <TeamBarDropdown />
+      {showDropdown && <TeamBarDropdown />}
       <Image
         src="/images/teambar-pattern.png"
         alt="teambar-thumbnail"


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
Closes #119 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 팀 페이지에서 팀 데이터(팀 이름, 할 일, 멤버 등) 불러오는 API 구현 및 적용
- 관리자, 멤버에 따라 보여지는 화면 다르게 구현
- 멤버 박스 반응형에서 어긋나는 부분 있어 수정
- 팀 바 설정 버튼 관리자에게만 보이도록 수정

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. swagger에서 회원가입, 로그인, 임시 팀 생성 후 생성된 팀 아이디 링크에 넣어 확인
2. 
3.

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
- 팀 데이터를 불러오는 데까지 API 구현되어 있으며 모달, 드롭다운 등에 해당하는 작업은 추후 구현 예정입니다. 남은 작업은 아래와 같습니다!

## TODO
- TeamBar
	- [ ] 팀 수정 페이지 연결
	- [ ] 팀 삭제 api 연결
- ListGroup
	- [ ] 할 일 목록 추가 api 연결
	- [ ] 할 일 목록 수정 모달, api 연결
	- [ ] 할 일 목록 삭제 모달 만들기
	- [ ] 할 일 목록 삭제 모달, api 연결
- MemberGroup
	- [ ] 멤버 초대하기 링크 api 연결
	- [ ] 초대 링크 복사 토스트
	- [ ] 이메일 복사하기 토스트
	- [ ] 멤버 삭제 모달 만들기
	- [ ] 멤버 삭제 모달, api 연결 
