### PR TITLE
✨ feat: 팀페이지 리다이렉트 로직 적용

### DIFF
--- a/src/app/(workspace)/[teamId]/edit/layout.tsx
+++ b/src/app/(workspace)/[teamId]/edit/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Header from "@/layouts/Header/Header";
-import SimpleLayout from "@/layouts/SimpleLayout";
+import InnerLayout from "@/layouts/InnerLayout";
 
 export default function TeamEditLayout({
   children,
@@ -11,7 +11,7 @@ export default function TeamEditLayout({
   return (
     <>
       <Header />
-      <SimpleLayout>{children}</SimpleLayout>
+      <InnerLayout>{children}</InnerLayout>
     </>
   );
 }

--- a/src/app/invite/layout.tsx
+++ b/src/app/invite/layout.tsx
@@ -1,9 +1,9 @@
 import Header from "@/layouts/Header/Header";
-import MainLayout from "@/layouts/MainLayout";
+import InnerLayout from "@/layouts/InnerLayout";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
-export default async function DashboardLayout({
+export default async function InvitePageLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -18,7 +18,7 @@ export default async function DashboardLayout({
   return (
     <>
       <Header />
-      <MainLayout>{children}</MainLayout>
+      <InnerLayout>{children}</InnerLayout>
     </>
   );
 }

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -51,7 +51,7 @@ export default function InviteAcceptPage() {
   }, [acceptInvitation, myInfo?.email, refetch, router, showToast, token]);
 
   return (
-    <div className="w-full h-screen flex justify-center items-center text-lg text-text-default">
+    <div className="w-full h-full flex justify-center pt-32 text-lg text-text-default">
       초대 수락 중...
     </div>
   );

--- a/src/layouts/InnerLayout.tsx
+++ b/src/layouts/InnerLayout.tsx
@@ -1,0 +1,13 @@
+export default function InnerLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="min-h-screen w-full flex items-start justify-center">
+      <div className="sm:w-[28.75rem] w-full mx-4 my-4 sm:my-[3.75rem] md:my-[6.25rem] my-flex flex-col items-center">
+        {children}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
Closes #133 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 팀페이지 리다이렉트 로직 구현
- 초대 페이지 리다이렉트 로직 구현
- `InnerLayout` 생성해서 적용

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 로그인하지 않은 상태에서 팀페이지와 초대 페이지에 접근하면 `/login` 링크로 이동됩니다.
2. 
3.

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
@jeonghwanJay 레이아웃 파일 두 개가 겹치면 스타일이 중복되어 접근되는 것 같아 InnerLayout을 만들어 팀 수정 페이지에도 적용해두었습니다. 관련하여 모바일에서의 `mt` 처리에 조절이 필요할 것 같아요!! 병합 후에 확인 한 번 부탁드립니다.

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
