### PR TITLE
✨ feat: 게시글 목록 페이지네이션 구현

### DIFF
--- a/src/api/article/article.query.ts
+++ b/src/api/article/article.query.ts
@@ -66,6 +66,7 @@ export const useArticleList = (params?: {
   return {
     ...query,
     data: query.data?.list ?? [],
+    totalCount: query.data?.totalCount ?? 0,
   };
 };
 

--- a/src/app/(board)/boards/page.tsx
+++ b/src/app/(board)/boards/page.tsx
@@ -2,38 +2,14 @@
 import SearchInput from "@/components/feature/Boards/List/SearchInput";
 import BoardBestList from "@/components/feature/Boards/List/BoardBestList";
 import BoardList from "@/components/feature/Boards/List/BoardList";
-import { useArticleList, useBestArticles } from "@/api/article/article.query";
-import { useState } from "react";
-import { ORDER_TYPE, OrderType } from "@/constants/orderType";
-import Pagination from "@/components/common/Pagination/Pagination";
 
 export default function BoardsPage() {
-  const [orderBy, setOrderBy] = useState<OrderType>(ORDER_TYPE.RECENT);
-  const [page, setPage] = useState(1);
-  const pageSize = 6;
-  const { data: bestList } = useBestArticles();
-  const { data: articleList, totalCount } = useArticleList({
-    page,
-    pageSize,
-    orderBy,
-  });
-
   return (
     <>
       <div className="flex flex-col w-full max-w-full">
         <SearchInput />
-        <BoardBestList data={bestList} />
-        <BoardList
-          data={articleList}
-          orderBy={orderBy}
-          setOrderBy={setOrderBy}
-        />
-        <Pagination
-          page={page}
-          setPage={setPage}
-          total={totalCount || 0}
-          pageSize={pageSize}
-        />
+        <BoardBestList />
+        <BoardList />
       </div>
     </>
   );

--- a/src/app/(board)/boards/page.tsx
+++ b/src/app/(board)/boards/page.tsx
@@ -5,13 +5,16 @@ import BoardList from "@/components/feature/Boards/List/BoardList";
 import { useArticleList, useBestArticles } from "@/api/article/article.query";
 import { useState } from "react";
 import { ORDER_TYPE, OrderType } from "@/constants/orderType";
+import Pagination from "@/components/common/Pagination/Pagination";
 
 export default function BoardsPage() {
   const [orderBy, setOrderBy] = useState<OrderType>(ORDER_TYPE.RECENT);
+  const [page, setPage] = useState(1);
+  const pageSize = 6;
   const { data: bestList } = useBestArticles();
-  const { data: articleList } = useArticleList({
-    page: 1,
-    pageSize: 6,
+  const { data: articleList, totalCount } = useArticleList({
+    page,
+    pageSize,
     orderBy,
   });
 
@@ -24,6 +27,12 @@ export default function BoardsPage() {
           data={articleList}
           orderBy={orderBy}
           setOrderBy={setOrderBy}
+        />
+        <Pagination
+          page={page}
+          setPage={setPage}
+          total={totalCount || 0}
+          pageSize={pageSize}
         />
       </div>
     </>

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -1,3 +1,5 @@
+import Button from "../Button";
+
 interface PaginationProps {
   page: number;
   setPage: (page: number) => void;
@@ -16,39 +18,37 @@ export default function Pagination({
 
   return (
     <nav className="flex justify-center items-center gap-2 mt-6 sm:mt-10">
-      <button
+      <Button
+        label="<-"
+        variant="primary"
         onClick={() => setPage(page - 1)}
         disabled={page === 1}
         className="px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-bg-tertiary text-bg-inverse border border-brand-primary hover:bg-brand-primary hover:text-text-inverse disabled:opacity-50"
-      >
-        ←
-      </button>
+      />
       {Array.from({ length: totalPages }, (_, idx) => {
         const p = idx + 1;
         const isActive = p === page;
         return (
-          <button
+          <Button
+            label={String(p)}
+            variant={isActive ? "primary" : "ghost"}
             key={p}
             onClick={() => setPage(p)}
-            className={`w-8 h-8 sm:w-10 sm:h-10 rounded-full font-bold border
-                ${
-                  isActive
-                    ? "bg-brand-primary text-text-inverse border-bg-secondary"
-                    : "bg-bg-secondary text-text-inverse border-bg-tertiary hover:bg-brand-primary hover:text-text-inverse"
-                }
+            className={`
+                text-md sm:text-lg w-8 h-8 sm:w-10 sm:h-10 rounded-full font-bold
+                ${isActive ? "border-bg-secondary" : "border-brand-primary"}
               `}
-          >
-            <span className="text-md sm:text-lg">{p}</span>
-          </button>
+            disabled={page === p}
+          />
         );
       })}
-      <button
+      <Button
+        label="->"
+        variant="primary"
         onClick={() => setPage(page + 1)}
         disabled={page === totalPages}
         className="px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-bg-tertiary text-text-inverse border border-brand-primary hover:bg-brand-primary hover:text-text-inverse disabled:opacity-50"
-      >
-        →
-      </button>
+      />
     </nav>
   );
 }

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -1,0 +1,54 @@
+interface PaginationProps {
+  page: number;
+  setPage: (page: number) => void;
+  total: number;
+  pageSize: number;
+}
+
+export default function Pagination({
+  page,
+  setPage,
+  total,
+  pageSize,
+}: PaginationProps) {
+  const totalPages = Math.ceil(total / pageSize);
+  if (totalPages === 0) return null;
+
+  return (
+    <nav className="flex justify-center items-center gap-2 mt-6 sm:mt-10">
+      <button
+        onClick={() => setPage(page - 1)}
+        disabled={page === 1}
+        className="px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-bg-tertiary text-bg-inverse border border-brand-primary hover:bg-brand-primary hover:text-text-inverse disabled:opacity-50"
+      >
+        ←
+      </button>
+      {Array.from({ length: totalPages }, (_, idx) => {
+        const p = idx + 1;
+        const isActive = p === page;
+        return (
+          <button
+            key={p}
+            onClick={() => setPage(p)}
+            className={`w-8 h-8 sm:w-10 sm:h-10 rounded-full font-bold border
+                ${
+                  isActive
+                    ? "bg-brand-primary text-text-inverse border-bg-secondary"
+                    : "bg-bg-secondary text-text-inverse border-bg-tertiary hover:bg-brand-primary hover:text-text-inverse"
+                }
+              `}
+          >
+            <span className="text-md sm:text-lg">{p}</span>
+          </button>
+        );
+      })}
+      <button
+        onClick={() => setPage(page + 1)}
+        disabled={page === totalPages}
+        className="px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-bg-tertiary text-text-inverse border border-brand-primary hover:bg-brand-primary hover:text-text-inverse disabled:opacity-50"
+      >
+        →
+      </button>
+    </nav>
+  );
+}

--- a/src/components/feature/Boards/List/BoardBestList.tsx
+++ b/src/components/feature/Boards/List/BoardBestList.tsx
@@ -1,7 +1,9 @@
 import ShortCard from "../Card/ShortCard";
 import { ArticleType } from "@/api/article/article.schema";
+import { useBestArticles } from "@/api/article/article.query";
 
-export default function BoardBestList({ data }: { data: ArticleType[] }) {
+export default function BoardBestList() {
+  const { data: bestList } = useBestArticles();
   return (
     <>
       <div className="flex items-center mt-[2.5rem] justify-between mb-[3.5rem]">
@@ -10,7 +12,7 @@ export default function BoardBestList({ data }: { data: ArticleType[] }) {
         </span>
       </div>
       <ul className="grid grid-cols-1 md:grid-cols-3 gap-[1.5rem] w-full overflow-hidden">
-        {data.map((post) => (
+        {bestList.map((post: ArticleType) => (
           <li key={post.id}>
             <ShortCard article={post} />
           </li>

--- a/src/components/feature/Boards/List/BoardList.tsx
+++ b/src/components/feature/Boards/List/BoardList.tsx
@@ -3,17 +3,22 @@ import LongCard from "../Card/LongCard";
 import { ArticleType } from "@/api/article/article.schema";
 import WriteButton from "./WriteButton";
 import { useRouter } from "next/navigation";
-import { OrderType } from "@/constants/orderType";
+import { OrderType, ORDER_TYPE } from "@/constants/orderType";
+import { useState } from "react";
+import Pagination from "@/components/common/Pagination/Pagination";
+import { useArticleList } from "@/api/article/article.query";
 
-export default function BoardList({
-  data,
-  orderBy,
-  setOrderBy,
-}: {
-  data: ArticleType[];
-  orderBy: OrderType;
-  setOrderBy: (order: OrderType) => void;
-}) {
+export default function BoardList() {
+  const [orderBy, setOrderBy] = useState<OrderType>(ORDER_TYPE.RECENT);
+  const [page, setPage] = useState(1);
+  const pageSize = 6;
+
+  const { data: articleList = [], totalCount = 0 } = useArticleList({
+    page,
+    pageSize,
+    orderBy,
+  });
+
   const router = useRouter();
 
   return (
@@ -23,12 +28,18 @@ export default function BoardList({
         <FilterDropdown orderBy={orderBy} setOrderBy={setOrderBy} />
       </div>
       <ul className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6 mb-10">
-        {data.map((post) => (
+        {articleList.map((post: ArticleType) => (
           <li key={post.id}>
             <LongCard article={post} />
           </li>
         ))}
       </ul>
+      <Pagination
+        page={page}
+        setPage={setPage}
+        total={totalCount}
+        pageSize={pageSize}
+      />
 
       <WriteButton onClick={() => router.push("/boards/new")} />
     </div>

--- a/src/components/feature/Boards/List/BoardList.tsx
+++ b/src/components/feature/Boards/List/BoardList.tsx
@@ -5,7 +5,7 @@ import WriteButton from "./WriteButton";
 import { useRouter } from "next/navigation";
 import { OrderType, ORDER_TYPE } from "@/constants/orderType";
 import { useState } from "react";
-import Pagination from "@/components/common/Pagination/Pagination";
+import Pagination from "@/components/feature/Boards/Pagination/Pagination";
 import { useArticleList } from "@/api/article/article.query";
 
 export default function BoardList() {

--- a/src/components/feature/Boards/Pagination/Pagination.tsx
+++ b/src/components/feature/Boards/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import Button from "../../../common/Button";
+import Button from "@/components/common/Button";
 
 interface PaginationProps {
   page: number;

--- a/src/components/feature/Boards/Pagination/Pagination.tsx
+++ b/src/components/feature/Boards/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import Button from "../Button";
+import Button from "../../../common/Button";
 
 interface PaginationProps {
   page: number;

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -41,7 +41,7 @@ export default function Header() {
   return (
     <>
       <header className="fixed top-0 left-0 w-full bg-bg-secondary z-50 h-15">
-        <div className="w-full h-[3.75rem] max-w-[78rem] mx-auto flex items-center justify-between px-4 py-5 sm:px-6 sm:py-3.5 md:px-7 md:py-[0.88rem]">
+        <div className="w-full h-[3.75rem] max-w-[78rem] mx-auto flex items-center justify-between px-4 py-5 sm:px-6 sm:py-3.5 md:px-7 md:py-[0.88rem] leading-none">
           <div className="flex items-center">
             {mockUser.teams.length > 0 && (
               <button


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->

closes #136 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->

- 게시글 목록 페이지 페이지네이션 구현 (6개씩 보이게)
-  BoardsPage에서 BoardList, BoardBestList 컴포넌트에 넘기던 데이터 패칭/상태 로직을 각 컴포넌트 내부로 이동

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/3f79dc48-252f-4e27-9562-a13ebe2900ba


## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. /boards 페이지 진입

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

리렌더링 관련 이슈로 처음 get 해올때는 scroll이 맨 위 BoardsPage로 올라가고, 두번째로 fetching 할때는 scroll이 전체게시글에서 보입니다. 해결해보려고 하였으나 아무리 찾아봐도 해결이 되지 않아 일단 멘토링 질문에 남겨놓은 상태로 이부분은 추후 리팩토링때 해결해보겠습니다. 혹시나 아시는분은 팀미팅때 공유해주시면 좋을 것 같습니다 !

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->

디자인이 살짝..? 애매한 것 같기도 한데, 모양이나 글자 색깔이나 등등 관련해서 피드백 주셔도 좋습니다.
