### PR TITLE
✨ feat: 헤더 및 드롭다운 API 연결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,12 @@ const nextConfig: NextConfig = {
         hostname: "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
       },
     ],
+    domains: [
+      "img1.kakaocdn.net",
+      "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
+      "k.kakaocdn.net",
+      "example.com",
+    ],
   },
   webpack: (config) => {
     config.module.rules.push({
@@ -17,12 +23,6 @@ const nextConfig: NextConfig = {
     });
 
     return config;
-  },
-  images: {
-    domains: [
-      "img1.kakaocdn.net",
-      "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
-    ],
   },
 };
 

--- a/src/api/user/user.query.ts
+++ b/src/api/user/user.query.ts
@@ -20,7 +20,7 @@ const userQuery = {
       queryKey: userQuery.myInfoKey(),
       queryFn: () => userService.getMyInfo(),
     }),
-  myGroupsKey: () => [...userQuery.all, "myGroups"],
+  myGroupsKey: () => ["group"],
   myGroups: () =>
     queryOptions({
       queryKey: userQuery.myGroupsKey(),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import LandingHeader from "@/layouts/Header/LandingHeader";
 import Toast from "@/components/common/Toast/Toast";
 import AuthProvider from "@/components/feature/Auth/AuthProvider/AuthProvider";
 import { cookies } from "next/headers";
+import Header from "@/layouts/Header/Header";
 
 const pretendard = localFont({
   src: "../assets/fonts/PretendardVariable.woff2",
@@ -31,7 +32,7 @@ export default async function RootLayout({
       <body className="bg-bg-primary text-white">
         <ReactQueryProvider>
           <AuthProvider hasToken={!!token}>
-            <LandingHeader />
+            {!token ? <LandingHeader /> : <Header />}
             {children}
             <div
               id="toast-root"

--- a/src/hooks/useImageFallback.ts
+++ b/src/hooks/useImageFallback.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export default function useImageFallback(
+  src: string | null | undefined,
+  fallback: string,
+): string {
+  const [validSrc, setValidSrc] = useState(fallback);
+
+  useEffect(() => {
+    if (!src) {
+      setValidSrc(fallback);
+      return;
+    }
+
+    const img = new Image();
+    img.src = src;
+    img.onload = () => setValidSrc(src);
+    img.onerror = () => setValidSrc(fallback);
+  }, [src, fallback]);
+
+  return validSrc;
+}

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -1,26 +1,36 @@
 "use client";
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Sidebar from "./Sidebar";
 import UserDropdown from "./UserDropdown";
 import TeamDropdown from "./TeamDropdown";
-
-const mockUser = {
-  //LATER: 실제 user API 연결
-  name: "안해나",
-  teams: [
-    { name: "경영관리팀", img: "/icons/icon-avatar.svg" },
-    { name: "프로덕트팀", img: "/icons/icon-avatar.svg" },
-    { name: "마케팅팀", img: "/icons/icon-avatar.svg" },
-  ],
-};
+import { useAuthStore } from "@/stores/authStore";
+import { useMyGroups } from "@/api/user/user.query";
+import { useTeamStore } from "@/stores/teamStore";
 
 export default function Header() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isTeamMenuOpen, setIsTeamMenuOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [currentTeam] = useState<string | null>(mockUser.teams[0].name || null);
+  const { data: teams } = useMyGroups();
+  const { user } = useAuthStore();
+  const { currentTeam, setCurrentTeam } = useTeamStore();
+
+  useEffect(() => {
+    if (!teams) return;
+
+    if (
+      currentTeam === null ||
+      !teams.some((team) => team.name === currentTeam)
+    ) {
+      if (teams.length > 0) {
+        setCurrentTeam(teams[0].name);
+      } else {
+        setCurrentTeam(null);
+      }
+    }
+  }, [teams, currentTeam, setCurrentTeam]);
 
   const toggleMenu = useCallback(() => {
     setIsMenuOpen((prev) => !prev);
@@ -38,12 +48,16 @@ export default function Header() {
     setIsSidebarOpen(false);
   }, []);
 
+  const handleTeamClick = (name: string) => {
+    setCurrentTeam(name);
+  };
+
   return (
     <>
       <header className="fixed top-0 left-0 w-full bg-bg-secondary z-50 h-15">
         <div className="w-full h-[3.75rem] max-w-[78rem] mx-auto flex items-center justify-between px-4 py-5 sm:px-6 sm:py-3.5 md:px-7 md:py-[0.88rem]">
           <div className="flex items-center">
-            {mockUser.teams.length > 0 && (
+            {teams && teams.length > 0 && (
               <button
                 onClick={handleMenuClick}
                 className="block sm:hidden mr-4"
@@ -77,18 +91,23 @@ export default function Header() {
             </Link>
 
             <div className="hidden sm:flex items-center sm:gap-8 md:gap-10">
-              {mockUser.teams.length > 1 ? (
+              {teams && teams.length > 0 ? (
                 <TeamDropdown
-                  teams={mockUser.teams}
+                  teams={teams.map((team) => ({
+                    name: team.name,
+                    img: team.image ?? "/icons/icon-avatar.svg",
+                    id: team.id, // 기본 이미지 처리
+                  }))}
                   currentTeam={currentTeam}
                   isOpen={isTeamMenuOpen}
                   onToggle={toggleTeamMenu}
                   onClose={() => setIsTeamMenuOpen(false)}
+                  onTeamClick={handleTeamClick}
                 />
               ) : (
-                <span className="text-text-primary text-lg">
-                  {mockUser.teams[0].name}
-                </span>
+                <Link href="/create" className="text-text-primary text-lg">
+                  팀 생성
+                </Link>
               )}
 
               <Link href="/boards" className={"whitespace-nowrap text-lg"}>
@@ -100,7 +119,7 @@ export default function Header() {
           <div className="ml-auto">
             <div className="relative">
               <UserDropdown
-                userName={mockUser.name}
+                userName={user?.nickname ?? ""}
                 isOpen={isMenuOpen}
                 onToggle={toggleMenu}
                 onClose={() => setIsMenuOpen(false)}
@@ -112,9 +131,13 @@ export default function Header() {
 
       {isSidebarOpen && (
         <Sidebar
-          user={mockUser}
           currentTeam={currentTeam}
           onClose={handleCloseSidebar}
+          groups={
+            teams && teams.length > 0
+              ? teams.map((team) => ({ teamId: team.id, name: team.name }))
+              : null
+          }
         />
       )}
     </>

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -8,6 +8,7 @@ import TeamDropdown from "./TeamDropdown";
 import { useAuthStore } from "@/stores/authStore";
 import { useMyGroups } from "@/api/user/user.query";
 import { useTeamStore } from "@/stores/teamStore";
+import useImageFallback from "@/hooks/useImageFallback";
 
 export default function Header() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -16,6 +17,7 @@ export default function Header() {
   const { data: teams } = useMyGroups();
   const { user } = useAuthStore();
   const { currentTeam, setCurrentTeam } = useTeamStore();
+  const userImg = useImageFallback(user?.image, "/icons/icon-avatar.svg");
 
   useEffect(() => {
     if (!teams) return;
@@ -96,7 +98,7 @@ export default function Header() {
                   teams={teams.map((team) => ({
                     name: team.name,
                     img: team.image ?? "/icons/icon-avatar.svg",
-                    id: team.id, // 기본 이미지 처리
+                    id: team.id,
                   }))}
                   currentTeam={currentTeam}
                   isOpen={isTeamMenuOpen}
@@ -120,7 +122,7 @@ export default function Header() {
             <div className="relative">
               <UserDropdown
                 userName={user?.nickname ?? ""}
-                userImg={user?.image ?? "/icons/icon-user.svg"}
+                userImg={userImg}
                 isOpen={isMenuOpen}
                 onToggle={toggleMenu}
                 onClose={() => setIsMenuOpen(false)}

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -120,6 +120,7 @@ export default function Header() {
             <div className="relative">
               <UserDropdown
                 userName={user?.nickname ?? ""}
+                userImg={user?.image ?? "/icons/icon-user.svg"}
                 isOpen={isMenuOpen}
                 onToggle={toggleMenu}
                 onClose={() => setIsMenuOpen(false)}

--- a/src/layouts/Header/Sidebar.tsx
+++ b/src/layouts/Header/Sidebar.tsx
@@ -2,20 +2,16 @@ import Link from "next/link";
 import Image from "next/image";
 
 interface Team {
+  teamId: number;
   name: string;
-  img: string;
 }
-
 interface SidebarProps {
-  user: {
-    name: string;
-    teams: Team[];
-  };
+  groups: Team[] | null;
   currentTeam: string | null;
   onClose: () => void;
 }
 
-export default function Sidebar({ user, onClose }: SidebarProps) {
+export default function Sidebar({ groups, onClose }: SidebarProps) {
   return (
     <aside className="fixed top-0 left-0 z-50 w-64 h-full bg-bg-secondary shadow-md p-6">
       <div className="flex justify-end mb-9">
@@ -30,8 +26,10 @@ export default function Sidebar({ user, onClose }: SidebarProps) {
       </div>
 
       <div className="flex flex-col gap-6">
-        {user.teams.map((team) => (
-          <div key={team.name}>{team.name}</div>
+        {groups?.map((team) => (
+          <Link href={`/${team.teamId}`} key={team.teamId}>
+            <span className="block">{team.name}</span>
+          </Link>
         ))}
 
         <Link href="/boards" className={"text-lg text-interaction-focus"}>

--- a/src/layouts/Header/TeamDropdown.tsx
+++ b/src/layouts/Header/TeamDropdown.tsx
@@ -3,10 +3,12 @@ import Image from "next/image";
 import DropDownMenu from "@/components/common/Dropdown/Menu";
 import DropDownItem from "@/components/common/Dropdown/Item";
 import useClickOutside from "@/hooks/useClickOutside";
+import Link from "next/link";
 
 interface Team {
   name: string;
   img: string;
+  id: number;
 }
 
 interface TeamDropdownProps {
@@ -15,6 +17,7 @@ interface TeamDropdownProps {
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
+  onTeamClick: (name: string) => void;
 }
 
 export default function TeamDropdown({
@@ -23,6 +26,7 @@ export default function TeamDropdown({
   isOpen,
   onToggle,
   onClose,
+  onTeamClick,
 }: TeamDropdownProps) {
   const ref = useClickOutside(onClose);
 
@@ -47,26 +51,33 @@ export default function TeamDropdown({
       >
         {teams.map((team) => (
           <DropDownItem
-            key={team.name}
+            key={team.id}
             className={`text-lg w-full h-11.5 flex items-center justify-between ${
               team.name === currentTeam ? "font-bold bg-bg-hover" : ""
             }`}
           >
-            <div className="flex items-center gap-2">
-              <Image src={team.img} alt={team.name} width={24} height={24} />
-              {team.name}
-            </div>
-            <Image
-              src="/icons/icon-kebabs.svg"
-              width={3}
-              height={12}
-              alt="더보기"
-            />
+            <Link href={`/${team.id}`}>
+              <div
+                className="flex items-center gap-2"
+                onClick={() => onTeamClick(team.name)}
+              >
+                <Image
+                  src={team.img}
+                  alt={team.name}
+                  width={24}
+                  height={24}
+                  className="rounded-full object-cover"
+                />
+                {team.name}
+              </div>
+            </Link>
           </DropDownItem>
         ))}
-        <button className="mt-2 border-t w-full h-[3rem] text-center border border-white rounded-xl text-text-primary cursor-pointer">
-          + 팀 추가하기
-        </button>
+        <Link href="/create">
+          <span className="inline-block py-3.5 mt-2 border-t w-full text-center border border-white rounded-xl text-text-primary cursor-pointer">
+            + 팀 추가하기
+          </span>
+        </Link>
       </DropDownMenu>
     </div>
   );

--- a/src/layouts/Header/TeamDropdown.tsx
+++ b/src/layouts/Header/TeamDropdown.tsx
@@ -1,9 +1,9 @@
 "use client";
 import Image from "next/image";
 import DropDownMenu from "@/components/common/Dropdown/Menu";
-import DropDownItem from "@/components/common/Dropdown/Item";
 import useClickOutside from "@/hooks/useClickOutside";
 import Link from "next/link";
+import TeamListItem from "./TeamListItem";
 
 interface Team {
   name: string;
@@ -50,28 +50,7 @@ export default function TeamDropdown({
         className="absolute w-[13.5rem] text-center top-full mt-2 right-0"
       >
         {teams.map((team) => (
-          <DropDownItem
-            key={team.id}
-            className={`text-lg w-full h-11.5 flex items-center justify-between ${
-              team.name === currentTeam ? "font-bold bg-bg-hover" : ""
-            }`}
-          >
-            <Link href={`/${team.id}`}>
-              <div
-                className="flex items-center gap-2"
-                onClick={() => onTeamClick(team.name)}
-              >
-                <Image
-                  src={team.img}
-                  alt={team.name}
-                  width={24}
-                  height={24}
-                  className="rounded-full object-cover"
-                />
-                {team.name}
-              </div>
-            </Link>
-          </DropDownItem>
+          <TeamListItem key={team.id} team={team} onTeamClick={onTeamClick} />
         ))}
         <Link href="/create">
           <span className="inline-block py-3.5 mt-2 border-t w-full text-center border border-white rounded-xl text-text-primary cursor-pointer">

--- a/src/layouts/Header/TeamListItem.tsx
+++ b/src/layouts/Header/TeamListItem.tsx
@@ -1,0 +1,43 @@
+import DropDownItem from "@/components/common/Dropdown/Item";
+import useImageFallback from "@/hooks/useImageFallback";
+import { useTeamStore } from "@/stores/teamStore";
+import Image from "next/image";
+import Link from "next/link";
+import React from "react";
+
+interface Props {
+  team: { id: number; name: string; img: string };
+  onTeamClick: (name: string) => void;
+}
+
+function TeamListItem({ team, onTeamClick }: Props) {
+  const { currentTeam } = useTeamStore();
+  const teamImg = useImageFallback(team.img, "/icons/icon-avatar.svg");
+
+  return (
+    <DropDownItem
+      key={team.id}
+      className={`text-lg w-full h-11.5 flex items-center justify-between ${
+        team.name === currentTeam ? "font-bold bg-bg-hover" : ""
+      }`}
+    >
+      <Link href={`/${team.id}`}>
+        <div
+          className="flex items-center gap-2"
+          onClick={() => onTeamClick(team.name)}
+        >
+          <Image
+            src={teamImg}
+            alt={team.name}
+            width={24}
+            height={24}
+            className="rounded-full object-cover"
+          />
+          {team.name}
+        </div>
+      </Link>
+    </DropDownItem>
+  );
+}
+
+export default TeamListItem;

--- a/src/layouts/Header/UserDropdown.tsx
+++ b/src/layouts/Header/UserDropdown.tsx
@@ -37,13 +37,15 @@ export default function UserDropdown({
   return (
     <div ref={ref} className="relative">
       <button onClick={onToggle} className="flex gap-2 cursor-pointer">
-        <Image
-          src={userImg}
-          alt="프로필"
-          width={16}
-          height={16}
-          className="rounded-full cursor-pointer"
-        />
+        <div className="relative w-6 h-6 sm:w-4 sm:h-4">
+          <Image
+            src={userImg}
+            alt="프로필"
+            fill
+            className="rounded-full cursor-pointer"
+          />
+        </div>
+
         <span className="whitespace-nowrap text-md text-text-primary hidden md:inline-block">
           {userName}
         </span>

--- a/src/layouts/Header/UserDropdown.tsx
+++ b/src/layouts/Header/UserDropdown.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import DropDownMenu from "@/components/common/Dropdown/Menu";
 import DropDownItem from "@/components/common/Dropdown/Item";
 import useClickOutside from "@/hooks/useClickOutside";
+import { useSignOut } from "@/api/auth/auth.query";
 
 interface UserDropdownProps {
   userName: string;
@@ -19,6 +20,18 @@ export default function UserDropdown({
   onClose,
 }: UserDropdownProps) {
   const ref = useClickOutside(onClose);
+  const signOutMutation = useSignOut();
+
+  const handleSignOut = () => {
+    signOutMutation.mutate(undefined, {
+      onSuccess: () => {
+        if (typeof window !== "undefined") {
+          window.location.href = "/";
+        }
+      },
+    });
+  };
+
   return (
     <div ref={ref} className="relative">
       <button onClick={onToggle} className="flex gap-2 cursor-pointer">
@@ -47,7 +60,7 @@ export default function UserDropdown({
         <DropDownItem>
           <Link href="/user-setting">계정 설정</Link>
         </DropDownItem>
-        <DropDownItem>로그아웃</DropDownItem>
+        <DropDownItem onClick={handleSignOut}>로그아웃</DropDownItem>
       </DropDownMenu>
     </div>
   );

--- a/src/layouts/Header/UserDropdown.tsx
+++ b/src/layouts/Header/UserDropdown.tsx
@@ -8,6 +8,7 @@ import { useSignOut } from "@/api/auth/auth.query";
 
 interface UserDropdownProps {
   userName: string;
+  userImg: string;
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
@@ -15,6 +16,7 @@ interface UserDropdownProps {
 
 export default function UserDropdown({
   userName,
+  userImg,
   isOpen,
   onToggle,
   onClose,
@@ -36,7 +38,7 @@ export default function UserDropdown({
     <div ref={ref} className="relative">
       <button onClick={onToggle} className="flex gap-2 cursor-pointer">
         <Image
-          src="/icons/icon-user.svg"
+          src={userImg}
           alt="프로필"
           width={16}
           height={16}

--- a/src/stores/teamStore.ts
+++ b/src/stores/teamStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type TeamStore = {
+  currentTeam: string | null;
+  setCurrentTeam: (teamName: string | null) => void;
+};
+
+export const useTeamStore = create<TeamStore>((set) => ({
+  currentTeam: null,
+  setCurrentTeam: (teamName) => set({ currentTeam: teamName }),
+}));


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
closes #144

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
헤더 API 연결 했습니다.
팀 삭제 시 헤더와 즉각 연동 되도록 useMyGroups 의 쿼리 키를 수정했습니다.
각 팀 페이지 이동 및 로그아웃 기능 연동 했으며 로그아웃 시 랜딩 페이지로 이동 및 새로고침 됩니다.

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 로그인 후 헤더 확인해주시면 됩니다. (새로고침 필요)

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
현재 로그인/회원가입 시 랜딩 페이지로 리다이렉트 되어있어 헤더 변경을 위해서는 새로고침이 필요한 상황입니다.
테스트 결과 랜딩 페이지가 아닌 다른 경로로 리다이렉트 시 정상적으로 헤더 노출되는 부분 확인하여 이후 경로 수정 시 정상 반영될 것 같습니다.

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
