### PR TITLE
✨ feat: 팀 참여 페이지 기능 구현 및 API 연동

### DIFF
--- a/src/app/(team)/join/page.tsx
+++ b/src/app/(team)/join/page.tsx
@@ -1,18 +1,121 @@
 "use client";
-import TeamFormLayout from "@/components/feature/Team/TeamFormLayout";
-import { TEAM_FORM_LABELS } from "@/constants/team";
 
-const handleJoin = () => {};
+import TeamFormLayout from "@/components/feature/Team/TeamFormLayout";
+
+import { TEAM_FORM_LABELS } from "@/constants/team";
+import { TEAM_ERROR_MESSAGES } from "@/constants/team";
+
+import { useToastStore } from "@/stores/toastStore";
+
+import { useAcceptInvitation } from "@/api/group/group.query";
+import { useMyInfoQuery } from "@/api/user/user.query";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 export default function TeamJoinPage() {
+  const router = useRouter();
+  const { showToast } = useToastStore();
+  const { mutateAsync } = useAcceptInvitation();
+  const { data: myInfo } = useMyInfoQuery(true);
+
+  const [teamLink, setTeamLink] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isTouched, setIsTouched] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+
+  const validateTeamLink = (teamLink: string) =>
+    teamLink.trim() === "" ? TEAM_ERROR_MESSAGES.JOIN_REQUIRED : "";
+
+  useEffect(() => {
+    const trimmed = teamLink.trim();
+    setIsButtonDisabled(trimmed.length === 0);
+
+    if (isTouched) setErrorMessage(validateTeamLink(trimmed));
+  }, [teamLink, isTouched]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setTeamLink(value);
+    if (isTouched) {
+      setErrorMessage(validateTeamLink(value));
+    }
+  };
+
+  const handleInputBlur = () => {
+    setIsTouched(true);
+    setErrorMessage(validateTeamLink(teamLink));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleJoin();
+    }
+  };
+
+  const handleJoin = async (e?: React.FormEvent<HTMLFormElement>) => {
+    e?.preventDefault();
+    setIsTouched(true);
+
+    const trimmed = teamLink.trim();
+    const validationError = validateTeamLink(trimmed);
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setIsButtonDisabled(true);
+
+      const url = new URL(trimmed);
+      const token = url.searchParams.get("token");
+
+      if (!token) {
+        setErrorMessage(TEAM_ERROR_MESSAGES.JOIN_INVALID);
+        return;
+      }
+
+      const res = await mutateAsync({
+        token,
+        userEmail: myInfo?.email || "",
+      });
+
+      router.push(`/${res.groupId}`);
+    } catch (e: unknown) {
+      let errorMessage = "";
+
+      if (e instanceof Error) {
+        errorMessage = e.message;
+      }
+
+      if (errorMessage === "이미 그룹에 소속된 유저입니다.") {
+        showToast("이미 이 팀에 참여하고 있습니다.", "error");
+      } else {
+        showToast("유효하지 않은 팀 링크입니다.", "error");
+      }
+    } finally {
+      setIsLoading(false);
+      setIsButtonDisabled(false);
+    }
+  };
+
   return (
     <>
       <TeamFormLayout
         title="팀 참여하기"
-        buttonLabel="참여하기"
+        buttonLabel={isLoading ? "참여중..." : "참여하기"}
         placeholder="팀 링크를 입력해주세요."
         tip="공유받은 팀 링크를 입력해 참여할 수 있어요."
         onSubmit={handleJoin}
+        inputValue={teamLink}
+        onInputChange={handleInputChange}
+        onInputBlur={handleInputBlur}
+        onKeyDown={handleKeyDown}
+        isInputError={!errorMessage}
+        isButtonDisabled={isButtonDisabled || isLoading}
+        errorMessage={isTouched && errorMessage !== "" ? errorMessage : ""}
       >
         <span className="inline-block font-medium text-lg pb-[0.75rem]">
           {TEAM_FORM_LABELS.LINK}

--- a/src/components/feature/Team/TeamFormLayout.tsx
+++ b/src/components/feature/Team/TeamFormLayout.tsx
@@ -10,6 +10,7 @@ interface TeamFormLayoutProps {
   inputValue?: string;
   children: React.ReactNode;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onInputChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onInputBlur?: () => void;
   isInputError?: boolean;
@@ -25,6 +26,7 @@ export default function TeamFormLayout({
   inputValue,
   children,
   onSubmit,
+  onKeyDown,
   onInputChange,
   onInputBlur,
   isInputError,
@@ -45,6 +47,7 @@ export default function TeamFormLayout({
           onChange={onInputChange}
           onBlur={onInputBlur}
           error={!isInputError}
+          onKeyDown={onKeyDown}
         />
         {error && <TeamNameError message={errorMessage} />}
         <Button

--- a/src/constants/team.ts
+++ b/src/constants/team.ts
@@ -6,4 +6,7 @@ export const TEAM_FORM_LABELS = {
 
 export const TEAM_ERROR_MESSAGES = {
   MESSAGE: "팀 이름을 입력해주세요.",
+  JOIN_REQUIRED: "팀 링크를 입력해주세요.",
+  JOIN_INVALID: "유효하지 않은 팀 링크입니다.",
+  JOIN_ALREADY: "이미 이 팀에 참여하고 있습니다.",
 };


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
Closes #159 

## 📝 PR 유형
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
- [x] 입력 및 상태 관리
- 팀 링크 입력값 상태 관리
- Enter 키로도 제출 가능하도록 처리
- [x] 버튼 활성화 조건
- 입력값이 존재할 경우 참여하기 버튼 활성화
- 입력이 사라지면 버튼 비활성화
- [x] 페이지 라우팅
- 성공 시: 토스트 메시지 "팀에 성공적으로 참여했습니다." 및 팀 페이지로 이동
- 실패 시: 예외 상황에 따라 토스트 출력 및 처리
- [x] UX 처리
- 버튼 클릭 시 버튼 비활성화 및 로딩 스피너 표시
- [x] 예외 처리
- 존재하지 않는 링크: "유효하지 않은 팀 링크입니다."
- 이미 참여한 경우: "이미 이 팀에 참여하고 있습니다."



## 📸 스크린샷

https://github.com/user-attachments/assets/d0f6a289-1c82-4a41-a203-9db4e0e1b92e

https://github.com/user-attachments/assets/448bb9ed-39d2-46e4-90e1-4841959a6e86




## 🛠️ 테스트 방법
1. /join 페이지 진입
2. 유효한 팀 초대 링크 입력 → 정상 이동되는지 확인
3. 이미 참여된 팀 링크 입력 → "이미 이 팀에 참여하고 있습니다." 에러 토스트 노출 되는지 확인
4. 잘못된 링크 입력 → "유효하지 않은 팀 링크입니다." 에러 토스트  노출 되는지 확인
5. 버튼 비활성화 및 Input 유효성 검사 확인