### PR TITLE
✨ feat: 팀 수정 페이지 기능 구현 및 API 연동

### DIFF
--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,6 +1,10 @@
 import { useAuthStore } from "@/stores/authStore";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { authService } from "./auth.service";
+import { useRouter } from "next/navigation";
+import { userQuery } from "../user/user.query";
+import { userService } from "../user/user.service";
+import { useToastStore } from "@/stores/toastStore";
 
 //회원가입 뮤테이션
 export const useSignUp = () => {
@@ -17,11 +21,38 @@ export const useSignUp = () => {
 //로그인 뮤테이션
 export const useSignIn = () => {
   const setAuth = useAuthStore((state) => state.setAuth);
+  const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: authService.signIn,
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       setAuth(data.user);
+      try {
+        await queryClient.invalidateQueries({
+          queryKey: userQuery.myGroupsKey(),
+        });
+
+        const groups = await queryClient.fetchQuery({
+          queryKey: userQuery.myGroupsKey(),
+          queryFn: () => userService.getMyGroups(),
+        });
+
+        if (groups.length > 0) {
+          router.push(`/${groups[0].id}`);
+        } else {
+          router.push("/select");
+        }
+        showToast("로그인 성공", "success");
+      } catch (error) {
+        console.log(error);
+        showToast("그룹 정보를 불러오는 데 실패했습니다.", "error");
+        router.push("/select");
+      }
+    },
+    onError: () => {
+      showToast("이메일 혹은 비밀번호를 확인해주세요.", "error");
     },
   });
 };
@@ -41,11 +72,35 @@ export const useSignOut = () => {
 // 카카오 로그인 뮤테이션
 export const useKakaoOauth = () => {
   const setAuth = useAuthStore((state) => state.setAuth);
+  const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: authService.kakaoSignIn,
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       setAuth(data.user);
+      try {
+        await queryClient.invalidateQueries({
+          queryKey: userQuery.myGroupsKey(),
+        });
+
+        const groups = await queryClient.fetchQuery({
+          queryKey: userQuery.myGroupsKey(),
+          queryFn: () => userService.getMyGroups(),
+        });
+
+        if (groups.length > 0) {
+          router.push(`/${groups[0].id}`);
+        } else {
+          router.push("/select");
+        }
+        showToast("로그인 성공", "success");
+      } catch (error) {
+        console.log(error);
+        showToast("그룹 정보를 불러오는 데 실패했습니다.", "error");
+        router.push("/select");
+      }
     },
   });
 };

--- a/src/api/user/user.query.ts
+++ b/src/api/user/user.query.ts
@@ -12,7 +12,7 @@ import { UpdateMyInfoRequest } from "./user.schema";
 import { Message } from "../auth/auth.schema";
 import { useToastStore } from "@/stores/toastStore";
 
-const userQuery = {
+export const userQuery = {
   all: ["user"],
   myInfoKey: () => [...userQuery.all, "myInfo"],
   myInfo: () =>

--- a/src/app/(auth)/oauth/kakao/page.tsx
+++ b/src/app/(auth)/oauth/kakao/page.tsx
@@ -32,7 +32,6 @@ export default function KakaoCallbackPage() {
         {
           onSuccess: () => {
             showToast("로그인 성공", "success");
-            router.push("/");
           },
           onError: () => {
             showToast("로그인 실패", "error");

--- a/src/app/(auth)/user-setting/page.tsx
+++ b/src/app/(auth)/user-setting/page.tsx
@@ -9,7 +9,9 @@ import { useAuthStore } from "@/stores/authStore";
 export default function UserSettingPage() {
   const { user } = useAuthStore();
 
-  if (!user) return <div>로그인 정보가 없습니다.</div>;
+  if (user === undefined) return <div>로그인 정보 확인 중...</div>;
+
+  if (user === null) return <div>로그인 정보가 없습니다.</div>;
 
   return (
     <div className="w-full">

--- a/src/app/(board)/boards/[articleId]/edit/page.tsx
+++ b/src/app/(board)/boards/[articleId]/edit/page.tsx
@@ -19,21 +19,38 @@ export default function BoardsEditPage() {
   const { imageUrl, isImageUploading, handleImageUpload } =
     useImageUploadHandler();
 
-  const defaultFormValues = useMemo(
-    () => ({
+  const defaultFormValues = useMemo(() => {
+    let parsed = { content: "", token: "" };
+    try {
+      parsed = JSON.parse(article?.content ?? "");
+    } catch {
+      parsed = { content: article?.content ?? "", token: "" };
+    }
+
+    return {
       title: article?.title ?? "",
-      content: article?.content ?? "",
-    }),
-    [article?.title, article?.content],
-  );
+      content: parsed.content,
+      token: parsed.token,
+    };
+  }, [article]);
 
   if (isLoading || !article) return null;
 
   function handleSubmit(data: FormValues) {
+    const contentPayload: { content: string; token?: string } = {
+      content: data.content,
+    };
+
+    if (data.token?.trim()) {
+      contentPayload.token = data.token;
+    }
+
     const payload = {
-      ...data,
+      title: data.title,
+      content: JSON.stringify(contentPayload),
       image: imageUrl ?? article?.image ?? undefined,
     };
+
     editArticle(payload, {
       onSuccess: () => {
         showToast("게시글 수정 완료!", "success");

--- a/src/app/(team)/create/page.tsx
+++ b/src/app/(team)/create/page.tsx
@@ -23,6 +23,8 @@ export default function TeamCreatePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 
+  const isInputError = isTouched && !!teamNameError;
+
   const validateTeamName = (teamName: string) =>
     teamName.trim() === "" ? TEAM_ERROR_MESSAGES.MESSAGE : "";
 
@@ -95,7 +97,7 @@ export default function TeamCreatePage() {
         onSubmit={handleCreate}
         onInputChange={handleInputChange}
         onInputBlur={handleInputBlur}
-        isInputError={!teamNameError}
+        isInputError={isInputError}
         isButtonDisabled={isButtonDisabled || isLoading}
         errorMessage={isTouched && teamName.trim() === "" ? teamNameError : ""}
       >

--- a/src/app/(team)/join/page.tsx
+++ b/src/app/(team)/join/page.tsx
@@ -25,6 +25,8 @@ export default function TeamJoinPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 
+  const isInputError = isTouched && !!teamLink;
+
   const validateTeamLink = (teamLink: string) =>
     teamLink.trim() === "" ? TEAM_ERROR_MESSAGES.JOIN_REQUIRED : "";
 
@@ -113,7 +115,7 @@ export default function TeamJoinPage() {
         onInputChange={handleInputChange}
         onInputBlur={handleInputBlur}
         onKeyDown={handleKeyDown}
-        isInputError={!errorMessage}
+        isInputError={isInputError}
         isButtonDisabled={isButtonDisabled || isLoading}
         errorMessage={isTouched && errorMessage !== "" ? errorMessage : ""}
       >

--- a/src/app/(workspace)/[teamId]/edit/page.tsx
+++ b/src/app/(workspace)/[teamId]/edit/page.tsx
@@ -55,7 +55,7 @@ export default function TeamEditPage() {
     try {
       await updateGroupMutation.mutateAsync({
         name: editedTeamName,
-        image: teamProfileUrl,
+        image: teamProfileUrl?.trim() ? teamProfileUrl : undefined,
       });
 
       showToast("팀 정보가 성공적으로 수정되었습니다.", "success");

--- a/src/app/(workspace)/[teamId]/edit/page.tsx
+++ b/src/app/(workspace)/[teamId]/edit/page.tsx
@@ -1,27 +1,103 @@
 "use client";
+
 import TeamFormLayout from "@/components/feature/Team/TeamFormLayout";
 import ProfileUploader from "@/components/feature/Team/ProfileImageUploader";
-import { TEAM_FORM_LABELS } from "@/constants/team";
 
-const handleEdit = () => {};
+import { TEAM_FORM_LABELS, TEAM_ERROR_MESSAGES } from "@/constants/team";
+
+import { useUpdateGroup } from "@/api/group/group.query";
+import { useGroupQuery } from "@/api/group/group.query";
+
+import { useRouter, useParams } from "next/navigation";
+
+import { useToastStore } from "@/stores/toastStore";
+import { useTeamStore } from "@/stores/useTeamStore";
+
+import { useState, useEffect, useMemo } from "react";
 
 export default function TeamEditPage() {
+  const { showToast } = useToastStore();
+  const { teamId } = useParams() as { teamId: string };
+  const { data: groupData } = useGroupQuery(teamId);
+  const { teamName, setTeamName, teamProfileUrl, setTeamProfileUrl } =
+    useTeamStore();
+
+  const router = useRouter();
+  const groupId = groupData?.id;
+
+  const [editedTeamName, setEditedTeamName] = useState(teamName);
+  const [isTouched, setIsTouched] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (groupData) {
+      setTeamName(groupData.name);
+      setEditedTeamName(groupData.name);
+      setTeamProfileUrl(groupData.image ?? "");
+      setIsTouched(false);
+    }
+  }, [groupData, setTeamName, setTeamProfileUrl]);
+
+  const isInputError = isTouched && editedTeamName.trim() === "";
+
+  const isButtonDisabled = useMemo(() => {
+    if (!groupData) return true;
+    return editedTeamName.trim() === "";
+  }, [editedTeamName, groupData]);
+
+  const updateGroupMutation = useUpdateGroup(String(groupId));
+
+  const handleEdit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!groupId) return;
+    setIsLoading(true);
+
+    try {
+      await updateGroupMutation.mutateAsync({
+        name: editedTeamName,
+        image: teamProfileUrl,
+      });
+
+      showToast("팀 정보가 성공적으로 수정되었습니다.", "success");
+      router.push(`/${teamId}`);
+    } catch {
+      showToast("팀 수정에 실패했습니다.", "error");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
-    <>
-      <TeamFormLayout
-        title="팀 수정하기"
-        buttonLabel="수정하기"
-        onSubmit={handleEdit}
-        tip="팀 이름은 회사명이나 모임 이름 등으로 설정하면 좋아요."
-      >
-        <span className="inline-block font-medium text-lg pb-[0.75rem]">
-          {TEAM_FORM_LABELS.PROFILE}
-        </span>
-        <ProfileUploader />
-        <span className="inline-block font-medium text-lg pt-[1.5rem] pb-[0.75rem]">
-          {TEAM_FORM_LABELS.NAME}
-        </span>
-      </TeamFormLayout>
-    </>
+    <TeamFormLayout
+      title="팀 수정하기"
+      buttonLabel={isLoading ? "수정중..." : "수정하기"}
+      onSubmit={handleEdit}
+      tip="팀 이름은 직장명이나 오피셜 이름 등으로 설정하면 좋아요."
+      inputValue={editedTeamName}
+      onInputChange={(e) => {
+        setEditedTeamName(e.target.value);
+        setIsTouched(true);
+      }}
+      onInputBlur={() => {
+        if (editedTeamName.trim() === "") {
+          setIsTouched(true);
+        }
+      }}
+      isInputError={isInputError}
+      isButtonDisabled={isButtonDisabled || isLoading}
+      errorMessage={
+        isTouched && editedTeamName.trim() === ""
+          ? TEAM_ERROR_MESSAGES.MESSAGE
+          : ""
+      }
+    >
+      <span className="inline-block font-medium text-lg pb-[0.75rem]">
+        {TEAM_FORM_LABELS.PROFILE}
+      </span>
+      <ProfileUploader />
+      <span className="inline-block font-medium text-lg pt-[1.5rem] pb-[0.75rem]">
+        {TEAM_FORM_LABELS.NAME}
+      </span>
+    </TeamFormLayout>
   );
 }

--- a/src/app/(workspace)/[teamId]/page.tsx
+++ b/src/app/(workspace)/[teamId]/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/api/task-list/task-list.query";
 import TodoEditModal from "@/components/common/Modal/TodoEditModal";
 import { groupService } from "@/api/group/group.service";
+import Skeleton from "@/components/common/Skeleton/Skeleton";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -101,8 +102,26 @@ export default function DashboardPage() {
 
   if (isLoading || isMembershipLoading || !groupData || !memberships) {
     return (
-      <div className="w-full pt-20 flex items-center justify-center text-text-default">
-        로딩 중 ...
+      <div className="w-full flex flex-col gap-12">
+        <Skeleton className="h-16 w-full rounded-xl" />
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+        </div>
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="w-full h-[13.5625rem] rounded-xl" />
+        </div>
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-6 w-24" />
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 sm:gap-6">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-[4.25rem] rounded-xl w-full" />
+            ))}
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,11 +2,10 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { ReactQueryProvider } from "@/lib/reactQueryProvider";
-import LandingHeader from "@/layouts/Header/LandingHeader";
 import Toast from "@/components/common/Toast/Toast";
 import AuthProvider from "@/components/feature/Auth/AuthProvider/AuthProvider";
 import { cookies } from "next/headers";
-import Header from "@/layouts/Header/Header";
+import LandingHeaderWrap from "@/layouts/Header/LandingHeaderWrap";
 
 const pretendard = localFont({
   src: "../assets/fonts/PretendardVariable.woff2",
@@ -32,7 +31,7 @@ export default async function RootLayout({
       <body className="bg-bg-primary text-white">
         <ReactQueryProvider>
           <AuthProvider hasToken={!!token}>
-            {!token ? <LandingHeader /> : <Header />}
+            <LandingHeaderWrap />
             {children}
             <div
               id="toast-root"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import FeatureSection from "@/components/feature/Landing/FeatureSection";
 import InteractiveGridBg from "@/components/feature/Landing/InteractiveGridBg";
+import { useAuthStore } from "@/stores/authStore";
 
 import Image from "next/image";
 import Link from "next/link";
@@ -9,6 +10,7 @@ import { useCallback, useState } from "react";
 
 export default function Home() {
   const [mousePos, setMousePos] = useState({ x: -1, y: -1 });
+  const { isAuthenticated } = useAuthStore();
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -61,7 +63,7 @@ export default function Home() {
           </div>
         </div>
         <Link
-          href="/login"
+          href={isAuthenticated ? "/boards" : "/login"}
           className="absolute z-30 bottom-[9rem] sm:bottom-[12rem] left-4 right-4 max-w-[373px] bg-brand-gradient rounded py-3 mx-auto text-center rounded-[2rem]"
         >
           지금 시작하기

--- a/src/components/common/Modal/NoTokenModal.tsx
+++ b/src/components/common/Modal/NoTokenModal.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useModalStore } from "@/stores/modalStore";
+import Modal from "./Modal";
+
+interface NoTokenModalProps {
+  onConfirm: () => void;
+}
+
+export default function NoTokenModal({ onConfirm }: NoTokenModalProps) {
+  const { isOpen, modalType, closeModal } = useModalStore();
+
+  if (!isOpen || modalType !== "no-token") return null;
+
+  return (
+    <Modal
+      title="팀 참여 링크가 없습니다."
+      description={`참여 링크 없이 글을 작성할 경우, 이메일을 요구하는 등 다른 방식으로 팀원을 초대해야 합니다. \n계속 진행하시겠습니까?`}
+      buttonType="double-white-green"
+      cancelText="닫기"
+      confirmText="글 작성하기"
+      onConfirm={() => {
+        closeModal();
+        onConfirm();
+      }}
+      showCloseIcon={false}
+    />
+  );
+}

--- a/src/components/common/Skeleton/Skeleton.tsx
+++ b/src/components/common/Skeleton/Skeleton.tsx
@@ -1,0 +1,12 @@
+import clsx from "clsx";
+
+export default function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={clsx(
+        "animate-pulse bg-text-default dark:bg-bg-tertiary rounded",
+        className,
+      )}
+    />
+  );
+}

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -56,7 +56,7 @@ function Toast() {
             exit={exitVariants}
             transition={transition}
             onClick={hideToast}
-            className={`fixed left-1/2 bottom-20 relative overflow-hidden pointer-events-auto pl-[3.5rem] pr-6 py-3 rounded-xl bg-bg-secondary text-lg z-100 max-w-[22.5rem] w-full flex items-center relative ${typeTextColor[type]}`}
+            className={`fixed left-1/2 bottom-20 overflow-hidden pointer-events-auto pl-[3.5rem] pr-6 py-3 rounded-xl bg-bg-secondary text-lg z-100 max-w-[22.5rem] w-full flex items-center relative ${typeTextColor[type]}`}
           >
             <Icon type={type} />
             <div className="flex-1 flex items-center justify-center">

--- a/src/components/feature/Auth/LoginForm/LoginForm.tsx
+++ b/src/components/feature/Auth/LoginForm/LoginForm.tsx
@@ -9,9 +9,6 @@ import SendEmailModal from "./SendEmailModal";
 import { useForm } from "react-hook-form";
 import { useSignIn } from "@/api/auth/auth.query";
 import ErrorMsg from "@/components/common/Input/ErrorMsg";
-import { useAuthStore } from "@/stores/authStore";
-import { useRouter } from "next/navigation";
-import { useToastStore } from "@/stores/toastStore";
 
 type LoginForm = {
   email: string;
@@ -20,12 +17,9 @@ type LoginForm = {
 
 export default function LoginForm() {
   const { openModal } = useModalStore();
-  const { showToast } = useToastStore();
-  const [showPassword, setShowPasword] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const loginMutation = useSignIn();
-  const { setAuth } = useAuthStore();
-  const router = useRouter();
 
   const {
     register,
@@ -36,7 +30,7 @@ export default function LoginForm() {
   });
 
   const handlePasswordToggle = () => {
-    setShowPasword((prev) => !prev);
+    setShowPassword((prev) => !prev);
   };
 
   const openPasswordResetModal = () => {
@@ -44,22 +38,10 @@ export default function LoginForm() {
   };
 
   const onSubmit = (data: LoginForm) => {
-    loginMutation.mutate(
-      {
-        email: data.email,
-        password: data.password,
-      },
-      {
-        onSuccess: (data) => {
-          setAuth(data.user);
-          showToast("로그인 성공", "success");
-          router.push("/");
-        },
-        onError: () => {
-          showToast("이메일 혹은 비밀번호를 확인해주세요.", "error");
-        },
-      },
-    );
+    loginMutation.mutate({
+      email: data.email,
+      password: data.password,
+    });
   };
 
   return (
@@ -99,7 +81,7 @@ export default function LoginForm() {
         <ErrorMsg message={errors.password?.message} />
         <button
           type="button"
-          className="absolute right-0 mt-3 text-brand-primary text-lg font-medium underline text-md sm:text-lg"
+          className="absolute right-0 mt-3 text-brand-primary font-medium underline text-md sm:text-lg"
           onClick={openPasswordResetModal}
         >
           비밀번호를 잊으셨나요?

--- a/src/components/feature/Auth/LoginForm/SendEmailModal.tsx
+++ b/src/components/feature/Auth/LoginForm/SendEmailModal.tsx
@@ -9,7 +9,8 @@ import React, { useState } from "react";
 export default function SendEmailModal() {
   const [email, setEmail] = useState("");
   const sendEmailMutation = useSendResetPasswordMutation();
-  const redirectUrl = window.location.origin || "";
+  const redirectUrl =
+    typeof window !== "undefined" ? window.location.origin : "";
   const { closeModal } = useModalStore();
   const { showToast } = useToastStore();
 

--- a/src/components/feature/Auth/SettingForm/PasswordChanger.tsx
+++ b/src/components/feature/Auth/SettingForm/PasswordChanger.tsx
@@ -73,7 +73,7 @@ function PasswordChanger() {
             label="변경하기"
             variant="primary"
             size="sm"
-            className="h-8"
+            className="w-[4.3rem] h-8"
             onClick={openPasswordChangeModal}
           />
         }

--- a/src/components/feature/Auth/SettingForm/SettingForm.tsx
+++ b/src/components/feature/Auth/SettingForm/SettingForm.tsx
@@ -59,7 +59,7 @@ function SettingForm({ userName }: { userName: string }) {
               label="저장"
               variant="primary"
               size="sm"
-              className="w-18 h-8"
+              className="w-[3rem] h-8"
             />
           }
         />

--- a/src/components/feature/Auth/SignupForm/SignupForm.tsx
+++ b/src/components/feature/Auth/SignupForm/SignupForm.tsx
@@ -54,7 +54,11 @@ export default function SignupForm() {
         onSuccess: (data) => {
           showToast("회원가입을 성공했습니다", "success");
           setAuth(data.user);
-          router.push("/");
+          if (typeof window !== "undefined") {
+            window.location.href = "/select";
+          } else {
+            router.push("/select");
+          }
         },
         onError: (error) => {
           showToast(error.message, "error");

--- a/src/components/feature/Boards/Article/ArticleDetail.tsx
+++ b/src/components/feature/Boards/Article/ArticleDetail.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { useModalStore } from "@/stores/modalStore";
 import { useToastStore } from "@/stores/toastStore";
 import DeleteModal from "@/components/common/Modal/DeleteModal";
+import JoinButton from "./JoinButton";
 
 interface ArticleDetailProps {
   data: ArticleDetailType;
@@ -22,6 +23,14 @@ export default function ArticleDetail({ data }: ArticleDetailProps) {
   const deleteArticleMutation = useDeleteArticle();
 
   const isMyArticle = user?.id === data.writer.id;
+
+  let parsedContent = { content: data.content, token: null };
+
+  try {
+    parsedContent = JSON.parse(data.content);
+  } catch {
+    parsedContent = { content: data.content, token: null };
+  }
 
   const handleEdit = () => {
     router.push(`/boards/${data.id}/edit`);
@@ -68,7 +77,7 @@ export default function ArticleDetail({ data }: ArticleDetailProps) {
       <hr className="w-full border-t border-border-primary opacity-10" />
 
       <div className="flex justify-between items-center mt-5">
-        <div className="flex items-center gap-4 sm:gap-8 md:gap-20">
+        <div className="flex items-center gap-4 sm:gap-8 md:gap-10">
           <span className="text-text-primary text-sm sm:text-md">
             {data.writer.nickname}
           </span>
@@ -91,27 +100,34 @@ export default function ArticleDetail({ data }: ArticleDetailProps) {
         </div>
       )}
 
-      <section className="text-text-secondary text-md sm:text-lg py-12 sm:py-16 whitespace-pre-line !leading-6">
-        {data.content}
+      {parsedContent.token && <JoinButton token={parsedContent.token} />}
+
+      <section className="text-text-secondary text-md sm:text-lg py-10 sm:py-12 whitespace-pre-line !leading-6">
+        {parsedContent.content}
       </section>
 
-      <div className="flex items-center gap-4 border-b pb-6 mb-12">
-        <div className="flex items-center gap-3">
-          <Image
-            src="/icons/icon-comment.svg"
-            alt="댓글"
-            width={28}
-            height={28}
-          />
-          <span className="text-text-primary text-base">
+      <div className="flex items-center gap-4 border-b pb-6 mb-12 group">
+        <div className="flex items-center gap-3 transition-all duration-300 hover:scale-105">
+          <div className="relative">
+            <Image
+              src="/icons/icon-comment.svg"
+              alt="댓글"
+              width={28}
+              height={28}
+              className="transition-transform duration-300 group-hover:rotate-12"
+            />
+          </div>
+          <span className="text-text-primary text-base font-medium">
             {data.commentCount}개의 댓글
           </span>
         </div>
-        <LikeButton
-          isLiked={data.isLiked}
-          articleId={data.id}
-          likeCount={data.likeCount}
-        />
+        <div className="transform transition-all duration-300 hover:scale-110">
+          <LikeButton
+            isLiked={data.isLiked}
+            articleId={data.id}
+            likeCount={data.likeCount}
+          />
+        </div>
       </div>
     </>
   );

--- a/src/components/feature/Boards/Article/JoinButton.tsx
+++ b/src/components/feature/Boards/Article/JoinButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Button from "@/components/common/Button";
+import { useRouter } from "next/navigation";
+
+interface JoinButtonProps {
+  token?: string;
+}
+
+export default function JoinButton({ token }: JoinButtonProps) {
+  const router = useRouter();
+
+  if (!token) return null;
+
+  const handleClick = () => {
+    router.push(token);
+  };
+
+  return (
+    <div className="mt-8 group">
+      <Button
+        label="팀에 참여하기"
+        variant="primary"
+        iconPosition="left"
+        icon={
+          <svg
+            className="w-5 h-5 mr-2 transition-transform duration-200 group-hover:scale-110"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"
+            />
+          </svg>
+        }
+        onClick={handleClick}
+        className="!w-40 sm:w-auto transition-all duration-200 hover:scale-105 hover:shadow-lg"
+      />
+    </div>
+  );
+}

--- a/src/components/feature/Boards/Card/LongCard.tsx
+++ b/src/components/feature/Boards/Card/LongCard.tsx
@@ -2,13 +2,9 @@
 import Image from "next/image";
 import { sharedCardStyles, longCardStyles } from "@/styles/sharedCardStyles";
 import { CardProps } from "./ShortCard";
-import { DEFAULT_PROFILE_IMG } from "./ShortCard";
 import { useRouter } from "next/navigation";
 
-export default function LongCard({
-  article,
-  profileImg = DEFAULT_PROFILE_IMG,
-}: CardProps) {
+export default function LongCard({ article }: CardProps) {
   const router = useRouter();
 
   const handleCardClick = () => {
@@ -48,15 +44,6 @@ export default function LongCard({
 
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3 flex-1 min-w-0">
-                      <div className="flex-shrink-0">
-                        <Image
-                          src={profileImg}
-                          alt="작성자"
-                          width={32}
-                          height={32}
-                          className={sharedCardStyles.profileImage}
-                        />
-                      </div>
                       <div className="flex-1 min-w-0">
                         <div
                           className={`${sharedCardStyles.authorName} truncate`}
@@ -85,15 +72,6 @@ export default function LongCard({
                 <div className="hidden sm:flex items-center justify-between gap-4 min-w-0">
                   <div className="flex items-center gap-4 min-w-0 flex-1">
                     <div className="flex items-center gap-3 min-w-0">
-                      <div className="flex-shrink-0">
-                        <Image
-                          src={profileImg}
-                          alt="작성자"
-                          width={32}
-                          height={32}
-                          className={sharedCardStyles.profileImage}
-                        />
-                      </div>
                       <div className="min-w-0 flex-1">
                         <div className={`${sharedCardStyles.authorName}`}>
                           {article.writer.nickname}
@@ -157,15 +135,6 @@ export default function LongCard({
 
             <div className="flex items-center justify-between">
               <div className={sharedCardStyles.authorSection}>
-                <div className="relative">
-                  <Image
-                    src={profileImg}
-                    alt="작성자"
-                    width={32}
-                    height={32}
-                    className={sharedCardStyles.profileImage}
-                  />
-                </div>
                 <div>
                   <div className={sharedCardStyles.authorName}>
                     {article.writer.nickname}

--- a/src/components/feature/Boards/Card/ShortCard.tsx
+++ b/src/components/feature/Boards/Card/ShortCard.tsx
@@ -8,13 +8,9 @@ export const DEFAULT_PROFILE_IMG = "/icons/icon-profile-default.svg";
 
 export interface CardProps {
   article: ArticleType;
-  profileImg?: string;
 }
 
-export default function ShortCard({
-  article,
-  profileImg = DEFAULT_PROFILE_IMG,
-}: CardProps) {
+export default function ShortCard({ article }: CardProps) {
   const router = useRouter();
 
   const handleCardClick = () => {
@@ -48,15 +44,6 @@ export default function ShortCard({
 
             <div className="border-gray-100 pt-[2.125rem]">
               <div className="flex gap-3 items-center">
-                <div>
-                  <Image
-                    src={profileImg}
-                    alt="작성자"
-                    width={32}
-                    height={32}
-                    className={sharedCardStyles.profileImage}
-                  />
-                </div>
                 <div className="flex-grow">
                   <div className={sharedCardStyles.authorName}>
                     {article.writer.nickname}
@@ -105,13 +92,6 @@ export default function ShortCard({
 
           <div className="mt-auto">
             <div className="flex gap-2 sm:gap-3  items-center">
-              <Image
-                src={profileImg}
-                alt="작성자"
-                width={32}
-                height={32}
-                className={sharedCardStyles.profileImage}
-              />
               <div className="flex-grow">
                 <div className={sharedCardStyles.authorName}>
                   {article.writer.nickname}

--- a/src/components/feature/Boards/List/BoardBestList.tsx
+++ b/src/components/feature/Boards/List/BoardBestList.tsx
@@ -7,9 +7,14 @@ export default function BoardBestList() {
   return (
     <>
       <div className="flex items-center mt-[2.5rem] justify-between mb-[3.5rem]">
-        <span className="sm:text-xl text-text-primary text-lg ">
-          베스트 게시글
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="bg-brand-primary text-white text-lg font-bold px-2 py-1 rounded-full">
+            Top 3
+          </span>
+          <span className="text-lg sm:text-xl text-text-primary">
+            인기 게시글
+          </span>
+        </div>
       </div>
       <ul className="grid grid-cols-1 md:grid-cols-3 gap-[1.5rem] w-full overflow-hidden">
         {bestList.map((post: ArticleType) => (

--- a/src/components/feature/Boards/List/SearchInput.tsx
+++ b/src/components/feature/Boards/List/SearchInput.tsx
@@ -13,9 +13,15 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
 
   return (
     <>
-      <span className="sm:text-2xl text-2lg text-text-primary mb-[2.5rem]">
-        모집게시판
-      </span>
+      <div className="flex items-center gap-10 mb-[2.5rem]">
+        <span className="sm:text-2xl text-2lg text-text-primary">
+          모집게시판
+        </span>
+        <span className="text-md text-text-secondary">
+          팀원을 모집하고, 일정을 함께 관리해보세요.
+        </span>
+      </div>
+
       <form
         onSubmit={(e) => e.preventDefault()}
         className="w-full p-[1rem] h-[3rem] sm:h-[3.5rem] gap-[0.75rem] bg-bg-secondary border border-card-border rounded-xl flex"

--- a/src/components/feature/Boards/New/BoardsForm.tsx
+++ b/src/components/feature/Boards/New/BoardsForm.tsx
@@ -10,6 +10,7 @@ import { useEffect } from "react";
 export interface FormValues {
   title: string;
   content: string;
+  token?: string;
 }
 
 export interface BoardsFormProps {
@@ -96,6 +97,29 @@ export default function BoardsForm({
           <span className={errorStyle}>{errors.title.message}</span>
         )}
       </LabeledField>
+      <LabeledField
+        id="token"
+        label={
+          <>
+            팀 참여 링크{" "}
+            <span className="ml-1 text-sm text-text-secondary">
+              (팀 참여 링크는 팀페이지에서 복사할 수 있습니다.)
+            </span>
+          </>
+        }
+      >
+        <Input
+          id="token"
+          placeholder="팀 참여 링크를 입력해주세요."
+          {...register("token")}
+          error={!!errors.token}
+          className={!!errors.token ? "hover:border-status-danger" : ""}
+        />
+        {errors.token && (
+          <span className={errorStyle}>{errors.token.message}</span>
+        )}
+      </LabeledField>
+
       <LabeledField id="content" label="내용" required>
         <Textarea
           id="content"

--- a/src/components/feature/Boards/New/LabeledField.tsx
+++ b/src/components/feature/Boards/New/LabeledField.tsx
@@ -1,6 +1,7 @@
+import { ReactNode } from "react";
 interface LabeledFieldProps {
   id: string;
-  label: string;
+  label: ReactNode;
   required?: boolean;
   children: React.ReactNode;
   className?: string;

--- a/src/components/feature/Team/ProfileImageUploader.tsx
+++ b/src/components/feature/Team/ProfileImageUploader.tsx
@@ -7,8 +7,12 @@ import { useTeamStore } from "@/stores/useTeamStore";
 import { useToastStore } from "@/stores/toastStore";
 
 export default function ProfileImageUploader() {
-  const { teamProfileFile, setTeamProfileFile, setTeamProfileUrl } =
-    useTeamStore();
+  const {
+    teamProfileFile,
+    setTeamProfileFile,
+    teamProfileUrl,
+    setTeamProfileUrl,
+  } = useTeamStore();
   const { showToast } = useToastStore();
   const uploadImageMutation = useUploadImage();
 
@@ -30,7 +34,9 @@ export default function ProfileImageUploader() {
     document.getElementById("team-profile-input")?.click();
   };
 
-  const preview = teamProfileFile ? URL.createObjectURL(teamProfileFile) : null;
+  const preview = teamProfileFile
+    ? URL.createObjectURL(teamProfileFile)
+    : teamProfileUrl || null;
 
   return (
     <div

--- a/src/components/feature/Team/TeamFormLayout.tsx
+++ b/src/components/feature/Team/TeamFormLayout.tsx
@@ -46,11 +46,12 @@ export default function TeamFormLayout({
           value={inputValue}
           onChange={onInputChange}
           onBlur={onInputBlur}
-          error={!isInputError}
+          error={isInputError}
           onKeyDown={onKeyDown}
         />
         {error && <TeamNameError message={errorMessage} />}
         <Button
+          type="submit"
           label={buttonLabel}
           variant="primary"
           className="w-full mt-[2.5rem] mb-[1.5rem]"

--- a/src/layouts/Header/LandingHeaderWrap.tsx
+++ b/src/layouts/Header/LandingHeaderWrap.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useAuthStore } from "@/stores/authStore";
+import LandingHeader from "./LandingHeader";
+import Header from "./Header";
+
+export default function LandingHeaderWrap() {
+  const { isAuthenticated } = useAuthStore();
+
+  if (isAuthenticated) return <Header />;
+  return <LandingHeader />;
+}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,15 +2,15 @@ import { UserType } from "@/api/user/user.schema";
 import { create } from "zustand";
 
 interface AuthState {
-  user: UserType | null;
+  user: UserType | null | undefined;
   isAuthenticated: boolean;
   setAuth: (user: UserType) => void;
   clearAuth: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
+  user: undefined,
   isAuthenticated: false,
   setAuth: (user) => set({ user, isAuthenticated: true }),
-  clearAuth: () => set({ user: null, isAuthenticated: false }),
+  clearAuth: () => set({ user: undefined, isAuthenticated: false }),
 }));

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -14,6 +14,7 @@ type ModalType =
   | "delete"
   | "delete-article"
   | "delete-article-comment"
+  | "no-token"
   | null;
 
 interface ModalState {

--- a/src/styles/sharedCardStyles.ts
+++ b/src/styles/sharedCardStyles.ts
@@ -6,7 +6,7 @@ export const sharedCardStyles = {
     "text-md sm:text-2lg text-text-secondary font-medium leading-relaxed overflow-hidden",
   profileImage:
     "rounded-full border-2 border-white shadow-sm w-6 h-6 sm:w-8 sm:h-8",
-  authorName: "text-sm text-text-Primary font-medium",
+  authorName: "text-md text-text-Primary font-medium",
   likesBadge:
     "flex gap-1 items-center bg-text-primary px-2 py-1 sm:px-3 sm:py-1.5 rounded-full",
   likesText: "text-sm text-text-disabled font-medium",
@@ -31,7 +31,7 @@ export const longCardStyles = {
   dateIndicator: `${sharedCardStyles.dateIndicator} h-5`,
   thumbnail:
     "w-[8rem] h-[8rem] rounded-xl overflow-hidden flex-shrink-0 relative shadow-md",
-  content: "px-5 pb-4 pt-5 w-full h-full flex items-center relative z-10",
+  content: "px-5 py-5 w-full h-full flex items-center relative z-10",
   contentNoThumbnail:
     "px-5 pb-4 pt-5 w-full h-full flex flex-col justify-between relative z-10",
   contentWithThumbnail: "ml-6 w-full h-full flex flex-col justify-between",


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
Closes #164 

## 📝 PR 유형
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
- [x] 상태 관리
- 현재 팀 이름/팀 프로필 상태 전역에서 가져오기
- 입력된 팀 이름 상태 관리
- 이미지 업로드 → 프로필 상태 업데이트
- [x] 기능 로직
- 기존 팀 이름 input에 초기값 세팅
- 변경 성공 시 토스트 노출 및 팀 페이지 이동
- 수정 중 로딩 상태 처리
- [x] 유효성 검사
- 팀 이름 필수 입력 (빈값 시 버튼 비활성화)
- [x] 예외 처리 및 UX
- 에러 발생 시 → "팀 수정에 실패했습니다" 토스트
- [x] API 연동
- 이미지 업로드 API 연동
- 응답 받은 데이터로 상태 업데이트 및 페이지 이동
- 팀 생성/수정/참여 페이지 Input error 처리 통일
## 📸 스크린샷

https://github.com/user-attachments/assets/d1127b66-c9ca-4dd9-b9c2-0ae2417cb4e8



## 🛠️ 테스트 방법
1. /[teamId]/edit 경로로 직접 진입
2. 기존 팀 이름, 프로필 이미지 자동 반영 되는지 확인
3. 이름 수정 후 "수정하기" 버튼 클릭 → 토스트 및 페이지 이동 확인
4. 빈 값 입력 시 에러 메시지 및 버튼 비활성화 확인