### PR TITLE
🐛 fix: auth 관련 페이지 버그 수정

### DIFF
--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -1,8 +1,12 @@
+"use client";
+
 const BASE_URL = "/api/proxy";
 
 type FetcherOptions = RequestInit & {
   params?: Record<string, string | number | boolean>;
 };
+
+const isBrowser = typeof window !== "undefined";
 
 async function fetcher<T>(
   path: string,
@@ -11,6 +15,10 @@ async function fetcher<T>(
   options?: FetcherOptions,
   isRetry = false,
 ): Promise<T> {
+  if (!isBrowser) {
+    throw new Error("fetcher는 클라이언트 환경에서만 사용 가능합니다.");
+  }
+
   const url = new URL(`${BASE_URL}${path}`, window.location.origin);
 
   if (options?.params) {

--- a/src/app/(auth)/oauth/kakao/page.tsx
+++ b/src/app/(auth)/oauth/kakao/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useKakaoOauth } from "@/api/auth/auth.query";
+import LoadingSpinner from "@/components/common/AsyncBoundary/LoadingSpinner";
 import { useToastStore } from "@/stores/toastStore";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect } from "react";
@@ -45,5 +46,5 @@ export default function KakaoCallbackPage() {
     }
   }, []);
 
-  return <div>로그인 처리 중..</div>;
+  return <LoadingSpinner title="로그인 처리 중..." />;
 }

--- a/src/app/(auth)/reset-password/layout.tsx
+++ b/src/app/(auth)/reset-password/layout.tsx
@@ -1,11 +1,19 @@
 import SimpleLayout from "@/layouts/SimpleLayout";
 import AuthHeader from "@/layouts/Header/AuthHeader";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
-export default function ResetPasswordLayout({
+export default async function ResetPasswordLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("accessToken")?.value;
+
+  if (token) {
+    redirect("/");
+  }
   return (
     <>
       <AuthHeader />

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -131,6 +131,7 @@ export default function ResetPasswordPage() {
             variant="primary"
             size="md"
             className="mt-10 w-full"
+            disabled={resetPasswordMutation.isPending}
           />
         </form>
       </div>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -97,6 +97,9 @@ export default function ResetPasswordPage() {
                   );
                 },
               },
+              onChange: (e) => {
+                e.target.value = e.target.value.replace(/\s/g, "");
+              },
             })}
             suffix={
               <PasswordToggle
@@ -116,6 +119,9 @@ export default function ResetPasswordPage() {
               required: "비밀번호 확인을 입력해주세요.",
               validate: (value) =>
                 value === password || "비밀번호가 일치하지 않습니다.",
+              onChange: (e) => {
+                e.target.value = e.target.value.replace(/\s/g, "");
+              },
             })}
             suffix={
               <PasswordToggle

--- a/src/components/common/Modal/PasswordChangeModal.tsx
+++ b/src/components/common/Modal/PasswordChangeModal.tsx
@@ -65,6 +65,9 @@ export default function PasswordChangeModal({
                 );
               },
             },
+            onChange: (e) => {
+              e.target.value = e.target.value.replace(/\s/g, "");
+            },
           })}
           error={!!errors.newPassword?.message}
         />
@@ -81,6 +84,9 @@ export default function PasswordChangeModal({
             required: "비밀번호 확인을 입력해주세요.",
             validate: (value) =>
               value === newPassword || "비밀번호가 일치하지 않습니다.",
+            onChange: (e) => {
+              e.target.value = e.target.value.replace(/\s/g, "");
+            },
           })}
           error={!!errors.confirmPassword?.message}
         />

--- a/src/components/feature/Auth/KakaoLogin.tsx
+++ b/src/components/feature/Auth/KakaoLogin.tsx
@@ -13,20 +13,17 @@ const KAKAO_AUTH_URL = "https://kauth.kakao.com/oauth/authorize";
 
 export default function KakaoLogin({ message }: KaKaoLoginProps) {
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const { showToast } = useToastStore();
 
   const handleKakaoLogin = () => {
     setIsLoading(true);
-    setError(null);
 
     const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
     const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
 
     if (!REST_API_KEY || !REDIRECT_URI) {
-      setError("환경 변수가 설정되지 않았습니다.");
       setIsLoading(false);
-      showToast(error as string);
+      showToast("환경 변수가 설정되지 않았습니다.");
       return;
     }
 
@@ -34,14 +31,7 @@ export default function KakaoLogin({ message }: KaKaoLoginProps) {
 
     const kakaoAuthUrl = `${KAKAO_AUTH_URL}?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&state=${state}`;
 
-    try {
-      window.location.href = kakaoAuthUrl;
-    } catch (err) {
-      console.error("카카오 로그인 오류", err);
-      setError("카카오 로그인 페이지 이동 중 오류가 발생했습니다.");
-      setIsLoading(false);
-      showToast(error as string);
-    }
+    window.location.href = kakaoAuthUrl;
   };
 
   return (

--- a/src/components/feature/Auth/LoginForm/LoginForm.tsx
+++ b/src/components/feature/Auth/LoginForm/LoginForm.tsx
@@ -70,6 +70,9 @@ export default function LoginForm() {
           error={!!errors.password}
           {...register("password", {
             required: "비밀번호는 필수 입력입니다.",
+            onChange: (e) => {
+              e.target.value = e.target.value.replace(/\s/g, "");
+            },
           })}
           suffix={
             <PasswordToggle

--- a/src/components/feature/Auth/LoginForm/LoginForm.tsx
+++ b/src/components/feature/Auth/LoginForm/LoginForm.tsx
@@ -88,9 +88,10 @@ export default function LoginForm() {
         </button>
         <Button
           type="submit"
-          label="로그인"
+          label={loginMutation.isPending ? "로그인 중.." : "로그인"}
           variant="primary"
           className="mt-[4.75rem] w-full"
+          disabled={loginMutation.isPending}
         />
       </form>
       <SendEmailModal />

--- a/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
+++ b/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
@@ -2,6 +2,7 @@
 
 import { useUploadImage } from "@/api/image/image-api";
 import { useUpdateMyInfoMutation } from "@/api/user/user.query";
+import Button from "@/components/common/Button";
 import { useAuthStore } from "@/stores/authStore";
 import { useToastStore } from "@/stores/toastStore";
 import { processImageFile } from "@/utils/imageUploadHelpers";
@@ -9,102 +10,116 @@ import Image from "next/image";
 import React, { useCallback, useRef, useState } from "react";
 
 function ProfileImageUploader() {
+  const DEFAULT_IMAGE = "/icons/icon-profile-default.svg";
+  const DEFAULT_IMAGE_URL =
+    "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Coworkers/user/2186/icon-profile-default.svg";
+
   const inputRef = useRef<HTMLInputElement>(null);
   const { user, setAuth } = useAuthStore();
-  const initialImgSrc = user?.image || "/icons/icon-profile-default.svg";
-  const [imgSrc, setImgSrc] = useState(initialImgSrc);
+  const { showToast } = useToastStore();
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+  const imgSrc =
+    previewSrc ??
+    (user?.image === DEFAULT_IMAGE_URL
+      ? DEFAULT_IMAGE
+      : user?.image || DEFAULT_IMAGE);
   const imageUpload = useUploadImage();
   const updateMyInfoMutation = useUpdateMyInfoMutation();
-  const { showToast } = useToastStore();
 
   const handleClick = useCallback(() => {
     inputRef.current?.click();
   }, []);
 
-  const updateImagePreview = useCallback((newPreview: string | null) => {
-    if (newPreview) {
-      setImgSrc(newPreview);
-    }
-  }, []);
-
   const handleChange = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
       if (!file) return;
 
-      processImageFile(file, imgSrc, (newPreviewUrl, processedFile) => {
-        void processedFile;
-        if (newPreviewUrl) {
-          updateImagePreview(newPreviewUrl);
+      processImageFile(file, imgSrc, (previewUrl) => {
+        if (previewUrl) {
+          setPreviewSrc(previewUrl);
         }
       });
 
       imageUpload.mutate(file, {
         onSuccess: (uploadedUrl) => {
-          setImgSrc(uploadedUrl);
           updateMyInfoMutation.mutate(
             { image: uploadedUrl },
             {
               onSuccess: () => {
                 showToast("프로필 이미지를 변경하였습니다.", "success");
-              },
-              onError: (error) => {
-                console.log(error);
-                showToast("정보 수정을 실패했습니다.", "error");
-
-                setImgSrc(initialImgSrc);
                 if (user) {
-                  setAuth({ ...user, image: user.image });
+                  setAuth({ ...user, image: uploadedUrl });
                 }
+                setPreviewSrc(null); // 성공하면 preview 초기화
+              },
+              onError: () => {
+                showToast("정보 수정을 실패했습니다.", "error");
+                setPreviewSrc(null); // 실패 시 되돌림
               },
             },
           );
         },
-        onError: (error) => {
-          console.log(error);
-          setImgSrc(initialImgSrc);
-          showToast("이미지 변경을 실패했습니다.", "error");
-          if (user) {
-            setAuth({ ...user, image: user.image });
-          }
+        onError: () => {
+          showToast("이미지 업로드를 실패했습니다.", "error");
+          setPreviewSrc(null);
         },
       });
     },
-    [
-      user,
-      imageUpload,
-      imgSrc,
-      updateImagePreview,
-      showToast,
-      updateMyInfoMutation,
-      setAuth,
-      initialImgSrc,
-    ],
+    [imageUpload, updateMyInfoMutation, user, setAuth, showToast, imgSrc],
   );
 
+  const resetToDefaultImage = useCallback(() => {
+    updateMyInfoMutation.mutate(
+      { image: DEFAULT_IMAGE_URL },
+      {
+        onSuccess: () => {
+          showToast("기본 이미지로 변경하였습니다.", "success");
+          if (user) {
+            setAuth({ ...user, image: DEFAULT_IMAGE_URL });
+          }
+          setPreviewSrc(null);
+        },
+        onError: () => {
+          showToast("기본 이미지 변경에 실패했습니다.", "error");
+        },
+      },
+    );
+  }, [user, updateMyInfoMutation, setAuth, showToast]);
   return (
-    <div className="relative w-16 h-16 cursor-pointer" onClick={handleClick}>
-      <Image
-        className="rounded-full object-cover w-full h-full"
-        src={imgSrc}
-        alt="프로필"
-        width={64}
-        height={64}
-      />
-      <Image
-        className="absolute bottom-0 right-0 rounded-full object-cover border-bg-primary border-2"
-        src="/icons/icon-edit.svg"
-        alt="편집 아이콘"
-        width={19}
-        height={19}
-      />
-      <input
-        ref={inputRef}
-        type="file"
-        accept="image/*"
-        className="hidden"
-        onChange={handleChange}
-      />
+    <div className="flex items-end gap-2">
+      <div className="relative w-16 h-16 cursor-pointer" onClick={handleClick}>
+        <Image
+          className="rounded-full object-cover w-full h-full"
+          src={imgSrc}
+          alt="프로필"
+          width={64}
+          height={64}
+        />
+        <Image
+          className="absolute bottom-0 right-0 rounded-full object-cover border-bg-primary border-2"
+          src="/icons/icon-edit.svg"
+          alt="편집 아이콘"
+          width={19}
+          height={19}
+        />
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleChange}
+        />
+      </div>
+      {imgSrc !== DEFAULT_IMAGE && (
+        <Button
+          label="이미지 제거"
+          variant="ghost"
+          size="sm"
+          className="mt-2 w-[5rem]"
+          onClick={resetToDefaultImage}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
+++ b/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
@@ -51,11 +51,11 @@ function ProfileImageUploader() {
                 if (user) {
                   setAuth({ ...user, image: uploadedUrl });
                 }
-                setPreviewSrc(null); // 성공하면 preview 초기화
+                setPreviewSrc(null);
               },
               onError: () => {
                 showToast("정보 수정을 실패했습니다.", "error");
-                setPreviewSrc(null); // 실패 시 되돌림
+                setPreviewSrc(null);
               },
             },
           );

--- a/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
+++ b/src/components/feature/Auth/SettingForm/ProfileImageUploader.tsx
@@ -10,19 +10,14 @@ import Image from "next/image";
 import React, { useCallback, useRef, useState } from "react";
 
 function ProfileImageUploader() {
-  const DEFAULT_IMAGE = "/icons/icon-profile-default.svg";
-  const DEFAULT_IMAGE_URL =
-    "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Coworkers/user/2186/icon-profile-default.svg";
+  const DEFAULT_IMAGE =
+    "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Coworkers/user/2194/profile-default.png";
 
   const inputRef = useRef<HTMLInputElement>(null);
   const { user, setAuth } = useAuthStore();
   const { showToast } = useToastStore();
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
-  const imgSrc =
-    previewSrc ??
-    (user?.image === DEFAULT_IMAGE_URL
-      ? DEFAULT_IMAGE
-      : user?.image || DEFAULT_IMAGE);
+  const imgSrc = previewSrc ?? previewSrc ?? user?.image ?? DEFAULT_IMAGE;
   const imageUpload = useUploadImage();
   const updateMyInfoMutation = useUpdateMyInfoMutation();
 
@@ -71,12 +66,12 @@ function ProfileImageUploader() {
 
   const resetToDefaultImage = useCallback(() => {
     updateMyInfoMutation.mutate(
-      { image: DEFAULT_IMAGE_URL },
+      { image: DEFAULT_IMAGE },
       {
         onSuccess: () => {
           showToast("기본 이미지로 변경하였습니다.", "success");
           if (user) {
-            setAuth({ ...user, image: DEFAULT_IMAGE_URL });
+            setAuth({ ...user, image: DEFAULT_IMAGE });
           }
           setPreviewSrc(null);
         },

--- a/src/components/feature/Auth/SettingForm/SettingForm.tsx
+++ b/src/components/feature/Auth/SettingForm/SettingForm.tsx
@@ -29,8 +29,8 @@ function SettingForm({ userName }: { userName: string }) {
         onSuccess: () => {
           showToast("이름을 변경했습니다.", "success");
         },
-        onError: () => {
-          showToast("이름 변경을 실패했습니다.", "error");
+        onError: (error) => {
+          showToast(error.message, "error");
         },
       },
     );

--- a/src/components/feature/Auth/SignupForm/SignupForm.tsx
+++ b/src/components/feature/Auth/SignupForm/SignupForm.tsx
@@ -132,6 +132,9 @@ export default function SignupForm() {
                 );
               },
             },
+            onChange: (e) => {
+              e.target.value = e.target.value.replace(/\s/g, "");
+            },
           })}
           hasTopMargin
           suffix={
@@ -152,6 +155,9 @@ export default function SignupForm() {
             required: "비밀번호 확인을 입력해주세요.",
             validate: (value) =>
               value === password || "비밀번호가 일치하지 않습니다.",
+            onChange: (e) => {
+              e.target.value = e.target.value.replace(/\s/g, "");
+            },
           })}
           hasTopMargin
           suffix={


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
Closes #177 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
1. fetcher 함수 window not defined 오류 해결
2. 계정 설정 프로필 이미지 제거 기능 추가
3. 로그인 상태일 경우 비밀번호 재설정 페이지 접근 불가 처리
4. 로그인, 비밀번호 재설정 api 요청 중 버튼 disabled
5. 비밀번호 input 공백 입력 방지
6. 계정 설정 닉네임 변경 에러 토스트 문구 수정
7. 카카오 로그인 불필요 로직 삭제

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/c23642dc-e3e1-4aba-8d8f-d8dd2794fc4d)
기본 이미지가 아닐 경우에만 해당 버튼이 노출됩니다.

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. /user-setting 에서 프로필 이미지, 닉네임 변경
2. 로그인 상태에서 /reset-password 접근
3. /login /sign-up 등 비밀번호 입력 input 에서 공백 입력 시도

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
리팩토링은 추후 진행 예정입니다.
