### PR TITLE
✨ feat: 팀 생성/참여/선택 페이지 리다이렉트 로직 추가

### DIFF
--- a/src/app/(team)/ClientTeamLayout.tsx
+++ b/src/app/(team)/ClientTeamLayout.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Header from "@/layouts/Header/Header";
+import AuthHeader from "@/layouts/Header/AuthHeader";
+import SimpleLayout from "@/layouts/SimpleLayout";
+
+import { usePathname } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function ClientLayout({
+  children,
+  token,
+}: {
+  children: React.ReactNode;
+  token: string | undefined;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!token) {
+      router.replace("/login");
+    }
+  }, [token, router]);
+
+  const isAuthPage = pathname.includes("/create") || pathname.includes("/join");
+
+  return (
+    <>
+      {isAuthPage ? <AuthHeader /> : <Header />}
+      <SimpleLayout>{children}</SimpleLayout>
+    </>
+  );
+}

--- a/src/app/(team)/layout.tsx
+++ b/src/app/(team)/layout.tsx
@@ -1,24 +1,14 @@
-"use client";
+// Server Component
+import { cookies } from "next/headers";
+import ClientLayout from "@/app/(team)/ClientTeamLayout";
 
-import { usePathname } from "next/navigation";
-import Header from "@/layouts/Header/Header";
-import AuthHeader from "@/layouts/Header/AuthHeader";
-import SimpleLayout from "@/layouts/SimpleLayout";
-
-export default function TeamLayout({
+export default async function TeamLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
+  const cookieStore = await cookies();
+  const token = cookieStore.get("accessToken")?.value;
 
-  const isAuthPage =
-    pathname?.includes("/create") || pathname?.includes("/join");
-
-  return (
-    <>
-      {isAuthPage ? <AuthHeader /> : <Header />}
-      <SimpleLayout>{children}</SimpleLayout>
-    </>
-  );
+  return <ClientLayout token={token}>{children}</ClientLayout>;
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
Closes #179 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
1. 팀 생성/참여/선택 페이지 진입 시 로그인 하지 않은 상태라면 `/login` 으로 리다이렉트되도록 처리
2. `layout.tsx` (server) ↔ `ClientLayout.tsx` (client) 분리 구조 적용
3. `cookies()`와 `redirect()`는 서버에서 처리하고, `usePathname`, `useRouter` 등은 클라이언트에서 처리

## 📸 스크린샷
https://github.com/user-attachments/assets/033bb0e3-599e-4d27-8f5b-aa3c4e0ad8da

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 로그인 상태에서 생성/참여/선택 페이지 접근 → 정상 진입
2. 로그아웃 상태에서 접근 → `/login`으로 이동