### PR TITLE
🐛 fix: 모집글 생성, 수정 통합 버그 수정

### DIFF
--- a/src/api/article/article.query.ts
+++ b/src/api/article/article.query.ts
@@ -90,6 +90,7 @@ export const useEditArticle = (articleId: string) => {
     mutationFn: (body) => articleService.updateArticle(articleId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["article"] });
+      queryClient.invalidateQueries({ queryKey: ["articles"] });
     },
   });
 };

--- a/src/api/article/article.schema.ts
+++ b/src/api/article/article.schema.ts
@@ -18,7 +18,7 @@ export type ArticleDetailType = ArticleType & {
 };
 
 export type CreateArticleRequest = {
-  image?: string;
+  image?: string | null;
   content: string;
   title: string;
 };

--- a/src/app/(board)/boards/[articleId]/edit/page.tsx
+++ b/src/app/(board)/boards/[articleId]/edit/page.tsx
@@ -7,15 +7,31 @@ import { useRouter, useParams } from "next/navigation";
 import { useMemo } from "react";
 import { useImageUploadHandler } from "@/hooks/useImageUploadHandler";
 import { useToastStore } from "@/stores/toastStore";
+import { useAuthStore } from "@/stores/authStore";
+import { useEffect } from "react";
 
 export default function BoardsEditPage() {
+  const { user, isAuthenticated } = useAuthStore();
   const { articleId } = useParams();
   const router = useRouter();
   const { showToast } = useToastStore();
-  const { data: article, isLoading } = useArticleDetail(articleId as string);
+  const { data: article } = useArticleDetail(articleId as string);
   const { mutate: editArticle, isPending: isSubmitting } = useEditArticle(
     articleId as string,
   );
+
+  useEffect(() => {
+    if (isAuthenticated === false || user === undefined) {
+      router.replace("/login");
+    }
+  }, [isAuthenticated, user, router]);
+
+  useEffect(() => {
+    if (user && article && article.writer.id != user.id) {
+      router.replace(`/boards/${articleId}`);
+    }
+  }, [user, article, articleId, router]);
+
   const { imageUrl, isImageUploading, handleImageUpload } =
     useImageUploadHandler();
 
@@ -34,7 +50,7 @@ export default function BoardsEditPage() {
     };
   }, [article]);
 
-  if (isLoading || !article) return null;
+  if (!article) return null;
 
   function handleSubmit(data: FormValues) {
     const contentPayload: { content: string; token?: string } = {

--- a/src/app/(board)/boards/[articleId]/edit/page.tsx
+++ b/src/app/(board)/boards/[articleId]/edit/page.tsx
@@ -48,7 +48,7 @@ export default function BoardsEditPage() {
     const payload = {
       title: data.title,
       content: JSON.stringify(contentPayload),
-      image: imageUrl ?? article?.image ?? undefined,
+      image: imageUrl === null ? null : (imageUrl ?? article?.image),
     };
 
     editArticle(payload, {

--- a/src/app/(board)/boards/[articleId]/edit/page.tsx
+++ b/src/app/(board)/boards/[articleId]/edit/page.tsx
@@ -24,13 +24,7 @@ export default function BoardsEditPage() {
     if (isAuthenticated === false || user === undefined) {
       router.replace("/login");
     }
-  }, [isAuthenticated, user, router]);
-
-  useEffect(() => {
-    if (user && article && article.writer.id != user.id) {
-      router.replace(`/boards/${articleId}`);
-    }
-  }, [user, article, articleId, router]);
+  }, [user, isAuthenticated, router]);
 
   const { imageUrl, isImageUploading, handleImageUpload } =
     useImageUploadHandler();
@@ -50,7 +44,7 @@ export default function BoardsEditPage() {
     };
   }, [article]);
 
-  if (!article) return null;
+  if (user === undefined || !article) return null;
 
   function handleSubmit(data: FormValues) {
     const contentPayload: { content: string; token?: string } = {

--- a/src/app/(board)/boards/new/page.tsx
+++ b/src/app/(board)/boards/new/page.tsx
@@ -24,14 +24,20 @@ export default function BoardsNewPage() {
 
   const handleSubmit = useCallback(
     (data: FormValues) => {
+      if (isImageUploading) {
+        showToast("이미지 업로드 중입니다.", "info");
+        return;
+      }
+
       if (!data.token) {
         setPendingFormData(data);
         openModal("no-token");
         return;
       }
+
       submitForm(data);
     },
-    [openModal],
+    [isImageUploading, openModal, imageUrl],
   );
 
   const submitForm = (data: FormValues) => {

--- a/src/app/(board)/boards/new/page.tsx
+++ b/src/app/(board)/boards/new/page.tsx
@@ -10,6 +10,8 @@ import { useToastStore } from "@/stores/toastStore";
 import NoTokenModal from "@/components/common/Modal/NoTokenModal";
 import { useModalStore } from "@/stores/modalStore";
 import { useState } from "react";
+import { useAuthStore } from "@/stores/authStore";
+import { useEffect } from "react";
 
 export default function BoardsNewPage() {
   const router = useRouter();
@@ -21,6 +23,13 @@ export default function BoardsNewPage() {
   const [pendingFormData, setPendingFormData] = useState<FormValues | null>(
     null,
   );
+  const { isAuthenticated, user } = useAuthStore();
+
+  useEffect(() => {
+    if (isAuthenticated === false || user === undefined) {
+      router.replace("/login");
+    }
+  }, [isAuthenticated, user, router]);
 
   const handleSubmit = useCallback(
     (data: FormValues) => {
@@ -39,6 +48,8 @@ export default function BoardsNewPage() {
     },
     [isImageUploading, openModal, imageUrl],
   );
+
+  if (user === undefined) return null;
 
   const submitForm = (data: FormValues) => {
     const payload = {

--- a/src/components/feature/Boards/New/BoardsForm.tsx
+++ b/src/components/feature/Boards/New/BoardsForm.tsx
@@ -69,8 +69,15 @@ export default function BoardsForm({
     />
   );
 
+  const onValidSubmit = (data: FormValues) => {
+    onSubmit(data);
+  };
+
   return (
-    <form className="flex flex-col w-full" onSubmit={handleSubmit(onSubmit)}>
+    <form
+      className="flex flex-col w-full"
+      onSubmit={handleSubmit(onValidSubmit)}
+    >
       <div className="flex justify-between items-center mb-[2.5rem] mt-[1.5rem] sm:mt-0">
         <h1 className="text-text-primary text-2lg sm:text-xl">
           {isEdit ? "게시글 수정" : "게시글 쓰기"}

--- a/src/components/feature/Boards/New/BoardsForm.tsx
+++ b/src/components/feature/Boards/New/BoardsForm.tsx
@@ -16,7 +16,7 @@ export interface FormValues {
 export interface BoardsFormProps {
   isSubmitting: boolean;
   onSubmit: (data: FormValues) => void;
-  imageUrl?: string;
+  imageUrl?: string | null;
   onImageUpload: (file: File | null) => void;
   isImageUploading: boolean;
   mode: "create" | "edit";

--- a/src/components/feature/Boards/New/BoardsForm.tsx
+++ b/src/components/feature/Boards/New/BoardsForm.tsx
@@ -57,7 +57,8 @@ export default function BoardsForm({
       label={
         isSubmitting ? (isEdit ? "수정중" : "등록중") : isEdit ? "수정" : "등록"
       }
-      variant={isSubmitting ? "primary" : "ghost"}
+      variant="primary"
+      state={isSubmitting ? "disabled" : "default"}
       type="submit"
       disabled={isSubmitting}
       className="

--- a/src/components/feature/Boards/New/BoardsForm.tsx
+++ b/src/components/feature/Boards/New/BoardsForm.tsx
@@ -57,7 +57,7 @@ export default function BoardsForm({
       label={
         isSubmitting ? (isEdit ? "수정중" : "등록중") : isEdit ? "수정" : "등록"
       }
-      variant="primary"
+      variant={isSubmitting ? "primary" : "ghost"}
       type="submit"
       disabled={isSubmitting}
       className="

--- a/src/components/feature/Boards/New/ImageUploader.tsx
+++ b/src/components/feature/Boards/New/ImageUploader.tsx
@@ -11,7 +11,7 @@ import { useEffect } from "react";
 interface ImageUploaderProps {
   onChange?: (file: File | null) => void;
   disabled?: boolean;
-  imageUrl?: string;
+  imageUrl?: string | null;
 }
 
 export default function ImageUploader({
@@ -28,7 +28,7 @@ export default function ImageUploader({
     handleFileChange,
     handleRemoveClick,
     dragHandlers,
-  } = useImageUploader(onChange, disabled, imageUrl);
+  } = useImageUploader(onChange, disabled, imageUrl ?? undefined);
 
   useEffect(() => {
     if (imageUrl && !preview) {

--- a/src/hooks/useImageUploadHandler.ts
+++ b/src/hooks/useImageUploadHandler.ts
@@ -3,7 +3,7 @@ import { useUploadImage } from "@/api/image/image-api";
 
 // 이미지 업로드 공통 훅
 export function useImageUploadHandler() {
-  const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isImageUploading, setIsImageUploading] = useState(false);
   const uploadImageMutation = useUploadImage();
 
@@ -22,7 +22,7 @@ export function useImageUploadHandler() {
           },
         });
       } else {
-        setImageUrl(undefined);
+        setImageUrl(null);
       }
     },
     [uploadImageMutation],

--- a/src/hooks/useImageUploadHandler.ts
+++ b/src/hooks/useImageUploadHandler.ts
@@ -3,7 +3,7 @@ import { useUploadImage } from "@/api/image/image-api";
 
 // 이미지 업로드 공통 훅
 export function useImageUploadHandler() {
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [imageUrl, setImageUrl] = useState<string | null | undefined>();
   const [isImageUploading, setIsImageUploading] = useState(false);
   const uploadImageMutation = useUploadImage();
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 interface AuthState {
   user: UserType | null | undefined;
   isAuthenticated: boolean;
+  isLoading: boolean;
   setAuth: (user: UserType) => void;
   clearAuth: () => void;
 }
@@ -11,6 +12,7 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   user: undefined,
   isAuthenticated: false,
+  isLoading: true,
   setAuth: (user) => set({ user, isAuthenticated: true }),
   clearAuth: () => set({ user: undefined, isAuthenticated: false }),
 }));

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -4,7 +4,6 @@ import { create } from "zustand";
 interface AuthState {
   user: UserType | null | undefined;
   isAuthenticated: boolean;
-  isLoading: boolean;
   setAuth: (user: UserType) => void;
   clearAuth: () => void;
 }
@@ -12,7 +11,6 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   user: undefined,
   isAuthenticated: false,
-  isLoading: true,
   setAuth: (user) => set({ user, isAuthenticated: true }),
   clearAuth: () => set({ user: undefined, isAuthenticated: false }),
 }));


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->

closes #175 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->

#### 모집글 생성/수정 리다이렉트
- 로그인 안한 유저가 (/boards/new) 접근 시 로그인 페이지로 리다이렉트
- 로그인 안한 유저가 (/boards/[articleId]/edit)으로 이동 시 로그인 페이지로 리다이렉트
- 본인이 올린 게시글이 아닌 게시글의 수정 페이지 접근 시, 랜딩페이지로 리다이렉트

#### 모집 게시글 이미지 수정 시, 새로고침 해야만 반영되는 버그 해결
- 모집 게시글 이미지 수정 시 , 바로 게시글 목록에 반영

#### 수정할 때 이미지 제거했는데 그대로인 버그 해결

#### 버튼이 등록중, 수정중 일때 disabled 효과 적용

#### 게시글 생성 시 이미지 안올라가는 버그 수정

#### Hydration 에러 해결
- app/layout.tsx에 supressHydrationWarning 속성 추가

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

- 로그인 안한 유저가 생성, 수정 페이지 접근 시 로그인 페이지로 리다이렉트 처리

https://github.com/user-attachments/assets/7e0c8464-af46-4fcb-b025-29f055428693

- 유저가 다른 유저의 게시물 수정 페이지 접근시 랜딩페이지로 리다이렉트 처리

https://github.com/user-attachments/assets/9f5956eb-cebb-4565-81a6-e615f240b87a

- 모집 게시글 이미지 수정 시, 새로고침 해야만 반영되는 버그 수정

https://github.com/user-attachments/assets/a469c9f5-9de5-48c0-8e47-a93e52311e91

- 수정할 때 이미지 제거했는데 그대로인 버그 수정

https://github.com/user-attachments/assets/78653dc7-cb7f-4900-b32a-ef6bd9dcb5ac

- 게시글 생성 시 이미지 안올라가는 버그 수정 (참여 링크 있을때)

https://github.com/user-attachments/assets/bcdb3791-468e-4d54-bffa-e2f065360b26

- 게시글 생성 시 이미지 안올라가는 버그 수정 (참여 링크 없을때)

https://github.com/user-attachments/assets/ac1ce152-239b-410e-9b1c-cadc07180303

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 모집게시판에서 테스트하시면 됩니다

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

boards의 layout.tsx에 token으로 처리하려 하였으나, 그렇게 하면 게시글 목록이랑 상세게시글에 모든 유저가 못들어가서
csr로 page에다가 처리했더니 아무래도 ssr 방식보다는 느리게 리다이렉트가 되네요ㅠㅡㅠ 이게 제가 생각한 최선의 방식인데
더 빠른 리다이렉트 로직이 있다면 알려주셔도 좋습니다 !