### PR TITLE
🐛 fix: 초대 링크 복사 후 모달 및 중복 목록 처리 추가

### DIFF
--- a/src/app/(workspace)/[teamId]/page.tsx
+++ b/src/app/(workspace)/[teamId]/page.tsx
@@ -26,6 +26,7 @@ import {
 import TodoEditModal from "@/components/common/Modal/TodoEditModal";
 import { groupService } from "@/api/group/group.service";
 import Skeleton from "@/components/common/Skeleton/Skeleton";
+import SuccessInviteModal from "@/components/common/Modal/SuccessInviteModal";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -135,7 +136,19 @@ export default function DashboardPage() {
 
   const handleEditSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!editList) return;
+    if (!editList || !groupData) return;
+
+    const isDuplicate = groupData.taskLists.some(
+      (list) =>
+        list.name.trim() === editList.name.trim() &&
+        list.id.toString() !== editList.id,
+    );
+
+    if (isDuplicate) {
+      showToast("이미 해당 목록이 존재합니다.", "error");
+      return;
+    }
+
     updateMutation.mutate(
       { name: editList.name },
       {
@@ -186,8 +199,8 @@ export default function DashboardPage() {
     groupService.getInvitationToken(teamId).then((token) => {
       const inviteUrl = `${window.location.origin}/invite?token=${token}`;
       navigator.clipboard.writeText(inviteUrl);
-      showToast("초대 링크 복사 완료!", "success");
       closeModal();
+      openModal("success-invite");
     });
   };
 
@@ -353,7 +366,18 @@ export default function DashboardPage() {
         onChange={(e) => setTodoTitle(e.target.value)}
         onSubmit={(e) => {
           e.preventDefault();
-          if (!todoTitle.trim()) return;
+          const trimmedTitle = todoTitle.trim();
+          if (!trimmedTitle || !groupData) return;
+
+          const isDuplicate = groupData.taskLists.some(
+            (list) => list.name.trim() === trimmedTitle,
+          );
+
+          if (isDuplicate) {
+            showToast("이미 해당 목록이 존재합니다.", "error");
+            return;
+          }
+
           createTaskList(
             { name: todoTitle.trim() },
             {
@@ -371,6 +395,7 @@ export default function DashboardPage() {
         }}
       />
       <InviteModal onCopy={handleCopyInviteLink} />
+      <SuccessInviteModal />
     </div>
   );
 }

--- a/src/components/common/Modal/SuccessInviteModal.tsx
+++ b/src/components/common/Modal/SuccessInviteModal.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useModalStore } from "@/stores/modalStore";
+import Modal from "./Modal";
+import { useRouter } from "next/navigation";
+
+export default function SuccessInviteModal() {
+  const { isOpen, modalType, closeModal } = useModalStore();
+  const router = useRouter();
+
+  if (!isOpen || modalType !== "success-invite") return null;
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    closeModal();
+    router.push("/boards/new");
+  };
+
+  return (
+    <Modal
+      title="초대 링크 복사 완료!"
+      description={`초대 링크가 복사되었습니다. \n 지금 바로 보드를 만들어볼까요?`}
+      buttonType="double-white-green"
+      confirmText="보드 만들기"
+      cancelText="괜찮아요"
+      showCloseIcon={false}
+      confirmButtonType="submit"
+      onSubmit={onSubmit}
+    />
+  );
+}

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 type ModalType =
   | "invite"
+  | "success-invite"
   | "todo"
   | "todo-create"
   | "todo-edit"


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
Closes #190 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 초대 링크를 복사하면 새로운 모집 게시글 작성 페이지로 이동할 수 있는 모달을 추가했습니다.
- 중복된 할 일 목록 이름에 대한 처리를 할 일 목록 추가, 수정 부분에 추가했습니다.

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/fdddf0b7-2667-4c71-b2ab-8598b9c28437



## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 
2. 
3.

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
