### PR TITLE
🐛 fix: 팀 수정 페이지 버그 수정

### DIFF
--- a/src/app/(workspace)/[teamId]/edit/page.tsx
+++ b/src/app/(workspace)/[teamId]/edit/page.tsx
@@ -12,15 +12,23 @@ import { useRouter, useParams } from "next/navigation";
 
 import { useToastStore } from "@/stores/toastStore";
 import { useTeamStore } from "@/stores/useTeamStore";
+import { useAuthStore } from "@/stores/authStore";
 
 import { useState, useEffect, useMemo } from "react";
 
 export default function TeamEditPage() {
   const { showToast } = useToastStore();
+  const { user } = useAuthStore();
   const { teamId } = useParams() as { teamId: string };
   const { data: groupData } = useGroupQuery(teamId);
   const { teamName, setTeamName, teamProfileUrl, setTeamProfileUrl } =
     useTeamStore();
+
+  const DEFAULT_TEAM_PROFILE_IMAGE = "/icons/icon-img.svg";
+
+  const isMember = groupData?.members?.some(
+    (member) => member.userName === user?.nickname,
+  );
 
   const router = useRouter();
   const groupId = groupData?.id;
@@ -30,13 +38,25 @@ export default function TeamEditPage() {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    if (!isMember) {
+      router.replace(`/${teamId}`);
+    }
+
     if (groupData) {
       setTeamName(groupData.name);
       setEditedTeamName(groupData.name);
-      setTeamProfileUrl(groupData.image ?? "");
+      setTeamProfileUrl(groupData.image ?? DEFAULT_TEAM_PROFILE_IMAGE);
       setIsTouched(false);
     }
-  }, [groupData, setTeamName, setTeamProfileUrl]);
+  }, [
+    groupData,
+    setTeamName,
+    setTeamProfileUrl,
+    isMember,
+    router,
+    showToast,
+    teamId,
+  ]);
 
   const isInputError = isTouched && editedTeamName.trim() === "";
 

--- a/src/components/feature/Team/ProfileImageUploader.tsx
+++ b/src/components/feature/Team/ProfileImageUploader.tsx
@@ -44,7 +44,7 @@ export default function ProfileImageUploader() {
       onClick={handleBoxClick}
     >
       <div className="w-full h-full relative flex items-center justify-center bg-bg-secondary rounded-full overflow-hidden border-2 border-border-primary/10">
-        {preview ? (
+        {preview && preview !== "/icons/icon-img.svg" ? (
           <Image src={preview} alt="팀 프로필" className="object-cover" fill />
         ) : (
           <Image


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
Closes #185 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
1. 팀 수정 페이지는 관리자 외 접근할 수 없도록 변경했습니다.
2. 팀 프로필 이미지가 없을 경우 기본 이미지가 정상적으로 표시되도록 수정했습니다.

## 📸 스크린샷


https://github.com/user-attachments/assets/d70266d8-c186-4552-83de-9b4328f9a6df


## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 관리자 계정으로 기본 프로필 이미지로 생성된 팀 수정 페이지 접속
2. 기본 프로필 이미지 정상적으로 표시되는지 확인
1. 관리자가 아닌 멤버 계정으로 팀 페이지 접속
2. URL을 통해 팀 수정 페이지 접속
3. 접속 되지 않고, 팀 페이지로 리다이렉트 되는 것 확인