### PR TITLE
♻️ refactor: auth 페이지 비즈니스 로직 분리

### DIFF
--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -10,11 +10,22 @@ import { useTeamStore } from "@/stores/teamStore";
 //회원가입 뮤테이션
 export const useSignUp = () => {
   const setAuth = useAuthStore((state) => state.setAuth);
+  const { showToast } = useToastStore();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: authService.signUp,
     onSuccess: (data) => {
+      showToast("회원가입을 성공했습니다", "success");
       setAuth(data.user);
+      if (typeof window !== "undefined") {
+        window.location.href = "/select";
+      } else {
+        router.push("/select");
+      }
+    },
+    onError: (error) => {
+      showToast(error.message, "error");
     },
   });
 };
@@ -107,6 +118,10 @@ export const useKakaoOauth = () => {
         showToast("그룹 정보를 불러오는 데 실패했습니다.", "error");
         router.push("/select");
       }
+    },
+    onError: () => {
+      showToast("로그인 실패", "error");
+      router.push("/login");
     },
   });
 };

--- a/src/api/user/user.query.ts
+++ b/src/api/user/user.query.ts
@@ -50,6 +50,7 @@ export const useMyInfoQuery = (enabled: boolean) => {
 export const useUpdateMyInfoMutation = () => {
   const queryClient = useQueryClient();
   const setAuth = useAuthStore((state) => state.setAuth);
+  const { showToast } = useToastStore();
 
   return useMutation<Message, Error, UpdateMyInfoRequest>({
     mutationFn: (body) => userService.updateMyInfo(body),
@@ -58,6 +59,11 @@ export const useUpdateMyInfoMutation = () => {
 
       const newUser = await userService.getMyInfo();
       setAuth(newUser);
+
+      showToast("이름을 변경했습니다.", "success");
+    },
+    onError: (error) => {
+      showToast(error.message, "error");
     },
   });
 };
@@ -116,18 +122,31 @@ export const useSendResetPasswordMutation = () => {
 // 비밀번호 초기화 뮤테이션
 export const useResetPassword = () => {
   const router = useRouter();
+  const { showToast } = useToastStore();
 
   return useMutation({
     mutationFn: userService.resetPassword,
     onSuccess: () => {
+      showToast("비밀번호가 변경되었습니다.", "success");
       router.push("/login");
+    },
+    onError: () => {
+      showToast("입력 값을 확인해주세요.", "error");
     },
   });
 };
 
 // 비밀번호 재설정 뮤테이션
 export const useUpdatePassword = () => {
+  const { showToast } = useToastStore();
+
   return useMutation({
     mutationFn: userService.updatePassword,
+    onSuccess: () => {
+      showToast("비밀번호가 변경되었습니다.", "success");
+    },
+    onError: () => {
+      showToast("비밀번호 변경을 실패했습니다.", "error");
+    },
   });
 };

--- a/src/api/user/user.query.ts
+++ b/src/api/user/user.query.ts
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 import { UpdateMyInfoRequest } from "./user.schema";
 import { Message } from "../auth/auth.schema";
 import { useToastStore } from "@/stores/toastStore";
+import { useModalStore } from "@/stores/modalStore";
 
 export const userQuery = {
   all: ["user"],
@@ -97,8 +98,18 @@ export const useMyHistory = () => {
 
 // 비밀번호 초기화 메일 전송 뮤테이션
 export const useSendResetPasswordMutation = () => {
+  const { closeModal } = useModalStore();
+  const { showToast } = useToastStore();
+
   return useMutation({
     mutationFn: userService.sendResetPasswordEmail,
+    onSuccess: () => {
+      showToast("비밀번호 재설정 링크가 전송되었습니다.", "success");
+      closeModal();
+    },
+    onError: () => {
+      showToast("이메일을 확인해주세요.", "error");
+    },
   });
 };
 

--- a/src/app/(auth)/oauth/kakao/page.tsx
+++ b/src/app/(auth)/oauth/kakao/page.tsx
@@ -24,22 +24,11 @@ export default function KakaoCallbackPage() {
         return;
       }
 
-      kakaoMutation.mutate(
-        {
-          state: state || "",
-          redirectUri: redirectUri,
-          token: code,
-        },
-        {
-          onSuccess: () => {
-            showToast("로그인 성공", "success");
-          },
-          onError: () => {
-            showToast("로그인 실패", "error");
-            router.push("/login");
-          },
-        },
-      );
+      kakaoMutation.mutate({
+        state: state || "",
+        redirectUri: redirectUri,
+        token: code,
+      });
     } else {
       showToast("카카오 로그인 취소 또는 실패", "error");
       router.replace("/login");

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -5,8 +5,7 @@ import Button from "@/components/common/Button";
 import ErrorMsg from "@/components/common/Input/ErrorMsg";
 import Input from "@/components/common/Input/Input";
 import PasswordToggle from "@/components/common/Input/PasswordToggle";
-import { useToastStore } from "@/stores/toastStore";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 
@@ -19,8 +18,6 @@ export default function ResetPasswordPage() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") || "";
   const resetPasswordMutation = useResetPassword();
-  const { showToast } = useToastStore();
-  const router = useRouter();
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -33,22 +30,11 @@ export default function ResetPasswordPage() {
   } = useForm<ResetForm>({ mode: "onBlur" });
 
   const onSubmit = (data: ResetForm) => {
-    resetPasswordMutation.mutate(
-      {
-        passwordConfirmation: data.confirmPassword,
-        password: data.password,
-        token: token,
-      },
-      {
-        onSuccess: () => {
-          showToast("비밀번호가 변경되었습니다.", "success");
-          router.push("/login");
-        },
-        onError: () => {
-          showToast("입력 값을 확인해주세요.", "error");
-        },
-      },
-    );
+    resetPasswordMutation.mutate({
+      passwordConfirmation: data.confirmPassword,
+      password: data.password,
+      token: token,
+    });
   };
 
   const password = watch("password");

--- a/src/app/(auth)/user-setting/page.tsx
+++ b/src/app/(auth)/user-setting/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import LoadingSpinner from "@/components/common/AsyncBoundary/LoadingSpinner";
 import Input from "@/components/common/Input/Input";
 import PasswordChanger from "@/components/feature/Auth/SettingForm/PasswordChanger";
 import Secession from "@/components/feature/Auth/SettingForm/Secession";
@@ -9,7 +10,7 @@ import { useAuthStore } from "@/stores/authStore";
 export default function UserSettingPage() {
   const { user } = useAuthStore();
 
-  if (user === undefined) return <div>로그인 정보 확인 중...</div>;
+  if (user === undefined) return <LoadingSpinner />;
 
   if (user === null) return <div>로그인 정보가 없습니다.</div>;
 

--- a/src/components/feature/Auth/LoginForm/SendEmailModal.tsx
+++ b/src/components/feature/Auth/LoginForm/SendEmailModal.tsx
@@ -2,8 +2,6 @@
 
 import { useSendResetPasswordMutation } from "@/api/user/user.query";
 import PasswordResetModal from "@/components/common/Modal/PasswordResetModal";
-import { useModalStore } from "@/stores/modalStore";
-import { useToastStore } from "@/stores/toastStore";
 import React, { useState } from "react";
 
 export default function SendEmailModal() {
@@ -11,8 +9,6 @@ export default function SendEmailModal() {
   const sendEmailMutation = useSendResetPasswordMutation();
   const redirectUrl =
     typeof window !== "undefined" ? window.location.origin : "";
-  const { closeModal } = useModalStore();
-  const { showToast } = useToastStore();
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
@@ -24,12 +20,7 @@ export default function SendEmailModal() {
       { email, redirectUrl: redirectUrl },
       {
         onSuccess: () => {
-          showToast("비밀번호 재설정 링크가 전송되었습니다.", "success");
-          closeModal();
           setEmail("");
-        },
-        onError: () => {
-          showToast("이메일을 확인해주세요.", "error");
         },
       },
     );

--- a/src/components/feature/Auth/SettingForm/PasswordChanger.tsx
+++ b/src/components/feature/Auth/SettingForm/PasswordChanger.tsx
@@ -35,20 +35,10 @@ function PasswordChanger() {
       return;
     }
 
-    updatePasswordMutation.mutate(
-      {
-        passwordConfirmation: data.confirmPassword,
-        password: data.newPassword,
-      },
-      {
-        onSuccess: () => {
-          showToast("비밀번호가 변경되었습니다.", "success");
-        },
-        onError: () => {
-          showToast("비밀번호 변경을 실패했습니다.", "error");
-        },
-      },
-    );
+    updatePasswordMutation.mutate({
+      passwordConfirmation: data.confirmPassword,
+      password: data.newPassword,
+    });
 
     closeModal();
     reset();

--- a/src/components/feature/Auth/SettingForm/SettingForm.tsx
+++ b/src/components/feature/Auth/SettingForm/SettingForm.tsx
@@ -7,7 +7,6 @@ import Button from "@/components/common/Button";
 import { useForm } from "react-hook-form";
 import ErrorMsg from "@/components/common/Input/ErrorMsg";
 import { useUpdateMyInfoMutation } from "@/api/user/user.query";
-import { useToastStore } from "@/stores/toastStore";
 
 interface SettingForm {
   name: string;
@@ -20,20 +19,9 @@ function SettingForm({ userName }: { userName: string }) {
     formState: { errors },
   } = useForm<SettingForm>({ mode: "onBlur" });
   const updateMyInfoMutation = useUpdateMyInfoMutation();
-  const { showToast } = useToastStore();
 
   const onSubmit = (data: SettingForm) => {
-    updateMyInfoMutation.mutate(
-      { nickname: data.name },
-      {
-        onSuccess: () => {
-          showToast("이름을 변경했습니다.", "success");
-        },
-        onError: (error) => {
-          showToast(error.message, "error");
-        },
-      },
-    );
+    updateMyInfoMutation.mutate({ nickname: data.name });
   };
 
   return (

--- a/src/components/feature/Auth/SignupForm/SignupForm.tsx
+++ b/src/components/feature/Auth/SignupForm/SignupForm.tsx
@@ -5,9 +5,6 @@ import Button from "@/components/common/Button";
 import ErrorMsg from "@/components/common/Input/ErrorMsg";
 import Input from "@/components/common/Input/Input";
 import PasswordToggle from "@/components/common/Input/PasswordToggle";
-import { useAuthStore } from "@/stores/authStore";
-import { useToastStore } from "@/stores/toastStore";
-import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 
@@ -22,8 +19,6 @@ export default function SignupForm() {
   const [showPassword, setShowPasword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const signupMutation = useSignUp();
-  const { setAuth } = useAuthStore();
-  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -32,7 +27,6 @@ export default function SignupForm() {
   } = useForm<SignupForm>({
     mode: "onBlur",
   });
-  const { showToast } = useToastStore();
 
   const handlePasswordToggle = () => {
     setShowPasword((prev) => !prev);
@@ -43,28 +37,12 @@ export default function SignupForm() {
   };
 
   const onSubmit = (data: SignupForm) => {
-    signupMutation.mutate(
-      {
-        nickname: data.name,
-        email: data.email,
-        password: data.password,
-        passwordConfirmation: data.confirmPassword,
-      },
-      {
-        onSuccess: (data) => {
-          showToast("회원가입을 성공했습니다", "success");
-          setAuth(data.user);
-          if (typeof window !== "undefined") {
-            window.location.href = "/select";
-          } else {
-            router.push("/select");
-          }
-        },
-        onError: (error) => {
-          showToast(error.message, "error");
-        },
-      },
-    );
+    signupMutation.mutate({
+      nickname: data.name,
+      email: data.email,
+      password: data.password,
+      passwordConfirmation: data.confirmPassword,
+    });
   };
 
   const password = watch("password");


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->
closes #215

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
로그인, 회원가입, 비밀번호 재설정, 계정설정 query 관련 로직 query.ts 파일로 통합했습니다.
비밀번호 재설정 페이지 로딩 스피너 적용했습니다.

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 
2. 
3.

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
