### PR TITLE
🐛 fix: 댓글 줄바꿈 추가 및 비로그인시 헤더 수정

### DIFF
--- a/src/components/feature/Boards/Comment/CommentItem.tsx
+++ b/src/components/feature/Boards/Comment/CommentItem.tsx
@@ -77,7 +77,7 @@ export default function CommentItem({ comment, articleId }: CommentItemProps) {
           </div>
         ) : (
           <>
-            <span className="text-md sm:text-lg text-text-primary flex-1">
+            <span className="text-md sm:text-lg text-text-primary flex-1 break-all">
               {comment.content}
             </span>
             {isMyComment && (

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -126,13 +126,22 @@ export default function Header() {
 
           <div className="ml-auto">
             <div className="relative">
-              <UserDropdown
-                userName={user?.nickname ?? ""}
-                userImg={userImg}
-                isOpen={isMenuOpen}
-                onToggle={toggleMenu}
-                onClose={() => setIsMenuOpen(false)}
-              />
+              {user ? (
+                <UserDropdown
+                  userName={user.nickname}
+                  userImg={userImg}
+                  isOpen={isMenuOpen}
+                  onToggle={toggleMenu}
+                  onClose={() => setIsMenuOpen(false)}
+                />
+              ) : (
+                <Link
+                  href="/login"
+                  className={"whitespace-nowrap text-lg text-text-primary"}
+                >
+                  로그인
+                </Link>
+              )}
             </div>
           </div>
         </div>

--- a/src/layouts/Header/UserDropdown.tsx
+++ b/src/layouts/Header/UserDropdown.tsx
@@ -45,8 +45,11 @@ export default function UserDropdown({
 
   return (
     <div ref={ref} className="relative">
-      <button onClick={onToggle} className="flex gap-2 cursor-pointer">
-        <div className="relative w-6 h-6 sm:w-4 sm:h-4">
+      <button
+        onClick={onToggle}
+        className="flex gap-2 cursor-pointer items-center"
+      >
+        <div className="relative w-6 h-6 sm:w-6 sm:h-6">
           <Image
             src={userImg}
             alt="프로필"
@@ -55,7 +58,7 @@ export default function UserDropdown({
           />
         </div>
 
-        <span className="whitespace-nowrap text-md text-text-primary hidden md:inline-block">
+        <span className="whitespace-nowrap text-lg text-text-primary hidden md:inline-block">
           {userName}
         </span>
       </button>

--- a/src/layouts/Header/UserDropdown.tsx
+++ b/src/layouts/Header/UserDropdown.tsx
@@ -49,7 +49,7 @@ export default function UserDropdown({
         onClick={onToggle}
         className="flex gap-2 cursor-pointer items-center"
       >
-        <div className="relative w-6 h-6 sm:w-6 sm:h-6">
+        <div className="relative w-6 h-6">
           <Image
             src={userImg}
             alt="프로필"


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 -->

closes #216  

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->

- 비로그인 시 헤더 유저 부분 로그인이 뜨게 구현 
- 게시글 댓글 줄바꿈 추가
- 헤더에 유저부분 좀 더 크게 수정

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

- 게시글 댓글 줄바꿈 추가
![스크린샷 2025-06-20 오후 11 01 26](https://github.com/user-attachments/assets/9099a2f8-fdf6-4cf7-a259-bd548e819f4b)

- 비로그인시 헤더
![스크린샷 2025-06-20 오후 11 02 29](https://github.com/user-attachments/assets/981803e9-0de2-41c1-bef7-ebb7b2a430e7)

- 헤더 유저부분
![image](https://github.com/user-attachments/assets/870cd480-4270-4914-8b95-e0f989adaf63)



## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

비로그인시 헤더 부분에 유저 드롭다운보다는 로그인으로 바로 갈 수 있는게 나을 것 같아 수정하였습니다.
