### PR TITLE
🐛 fix: 팀 수정 페이지 버그 수정

### DIFF
--- a/src/app/(workspace)/[teamId]/edit/layout.tsx
+++ b/src/app/(workspace)/[teamId]/edit/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Header from "@/layouts/Header/Header";
 import InnerLayout from "@/layouts/InnerLayout";
 import { Metadata } from "next";

--- a/src/app/(workspace)/[teamId]/edit/page.tsx
+++ b/src/app/(workspace)/[teamId]/edit/page.tsx
@@ -25,6 +25,11 @@ export default function TeamEditPage() {
     useTeamStore();
 
   const DEFAULT_TEAM_PROFILE_IMAGE = "/icons/icon-img.svg";
+  const ABSOLUTE_DEFAULT_IMAGE_URL = `${process.env.NEXT_PUBLIC_API_URL}${DEFAULT_TEAM_PROFILE_IMAGE}`;
+
+  const imageUrlToSend = teamProfileUrl?.startsWith("/")
+    ? `${process.env.NEXT_PUBLIC_API_URL}${teamProfileUrl}`
+    : (teamProfileUrl ?? ABSOLUTE_DEFAULT_IMAGE_URL);
 
   const isMember = groupData?.members?.some(
     (member) => member.userName === user?.nickname,
@@ -45,7 +50,16 @@ export default function TeamEditPage() {
     if (groupData) {
       setTeamName(groupData.name);
       setEditedTeamName(groupData.name);
-      setTeamProfileUrl(groupData.image ?? DEFAULT_TEAM_PROFILE_IMAGE);
+
+      const rawImage = groupData.image;
+      const isDefaultImage = rawImage?.includes("/icons/icon-img.svg");
+
+      setTeamProfileUrl(
+        isDefaultImage
+          ? "/icons/icon-img.svg"
+          : (rawImage ?? DEFAULT_TEAM_PROFILE_IMAGE),
+      );
+
       setIsTouched(false);
     }
   }, [
@@ -75,7 +89,7 @@ export default function TeamEditPage() {
     try {
       await updateGroupMutation.mutateAsync({
         name: editedTeamName,
-        image: teamProfileUrl?.trim() ? teamProfileUrl : undefined,
+        image: imageUrlToSend,
       });
 
       showToast("팀 정보가 성공적으로 수정되었습니다.", "success");


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
Closes #234 

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 기본 프로필 이미지로 팀 생성 후 수정 시 400 에러 발생하던 문제 수정  
## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 기본 프로필 이미지로 팀 생성  
2. 팀 수정 페이지 진입 후 팀 이름 수정  

## 💡 추가 정보
수빈님이 작업해주신 metadata `layout.tsx` 파일에서 "use client"가 선언되어 있어 팀 수정 페이지 진입 시 에러가 발생했습니다.
서버 컴포넌트에서만 metadata를 사용할 수 있기 때문에 "use client"를 제거하여 해결했습니다.!

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
